### PR TITLE
feat(browser-auth): add support for Chrome-based browsers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ await rh.restoreSession();
 - **Do NOT use `phoenix.robinhood.com`** — it rejects TLS. Use `api.robinhood.com` endpoints only.
 
 ## Authentication
-- Browser login (`robinhood_browser_login`) opens system Chrome via playwright-core
+- Browser login (`robinhood_browser_login`) opens a Chromium-based browser via playwright-core. On macOS, Brave and Chrome are auto-detected; otherwise use `BROWSER_PATH` or `robinhood-for-agents login --chrome /path/to/browser`.
 - Purely passive — Playwright intercepts `/oauth2/token` network traffic, never interacts with the DOM
 - Request body (JSON) → captures `device_token`; Response → captures `access_token` + `refresh_token`
 - Tokens stored directly in OS keychain via `Bun.secrets` (never on disk)

--- a/bin/robinhood-for-agents.ts
+++ b/bin/robinhood-for-agents.ts
@@ -3,6 +3,17 @@ export {};
 
 const args = process.argv.slice(2);
 
+/** Parse --chrome / --browser path from argv (supports --chrome <path> or --chrome=<path>). */
+function parseBrowserPath(argv: string[]): string | undefined {
+  const idx = argv.findIndex((a) => a === "--chrome" || a === "--browser");
+  if (idx === -1) return undefined;
+  const flag = argv[idx];
+  const next = argv[idx + 1];
+  if (flag?.includes("=")) return flag.split("=", 2)[1]?.trim();
+  if (next && !next.startsWith("--")) return next;
+  return undefined;
+}
+
 if (args[0] === "onboard" || args[0] === "setup") {
   const { onboard } = await import("../src/server/cli/onboard.js");
   const agentFlag = args.find((a) => a.startsWith("--agent=") || a.startsWith("--agent "));
@@ -42,11 +53,23 @@ if (args[0] === "onboard" || args[0] === "setup") {
   if (both) {
     console.log("\nRestart Claude Code to pick up the changes.");
   }
+} else if (args[0] === "login") {
+  const executablePath = parseBrowserPath(args);
+  const { browserLogin, formatLoginSuccessMessage } = await import("../src/server/browser-auth.js");
+  try {
+    const result = await browserLogin(executablePath ? { executablePath } : undefined);
+    console.log(formatLoginSuccessMessage(result));
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : "Login failed.");
+    process.exit(1);
+  }
 } else if (args.includes("--help") || args.includes("-h")) {
   console.log(`robinhood-for-agents — AI-native Robinhood trading interface
 
 Usage:
   robinhood-for-agents                  Start the MCP server (stdio transport)
+  robinhood-for-agents login            Browser login (auto-detects Brave/Chrome on macOS)
+  robinhood-for-agents login --chrome <path>   Use specific browser (e.g. Brave)
   robinhood-for-agents onboard          Interactive setup TUI (all agents)
   robinhood-for-agents onboard --agent claude-code|openclaw|codex
   robinhood-for-agents install          Install MCP server config + skills (Claude Code)

--- a/skills/robinhood-for-agents/reference.md
+++ b/skills/robinhood-for-agents/reference.md
@@ -10,7 +10,7 @@ Check if a Robinhood session is active.
 **Response:** `{ "status": "logged_in" | "not_authenticated" }`
 
 ### robinhood_browser_login
-Open Chrome for browser-based Robinhood login. Captures OAuth tokens automatically.
+Open a Chromium-based browser (Brave/Chrome auto-detected on macOS, or `BROWSER_PATH`) for browser-based Robinhood login. Captures OAuth tokens automatically.
 
 **Parameters:** none
 

--- a/skills/robinhood-for-agents/setup.md
+++ b/skills/robinhood-for-agents/setup.md
@@ -15,12 +15,18 @@ If `logged_in` — already authenticated, stop. Otherwise continue.
 ```bash
 bunx robinhood-for-agents login
 ```
-This opens Chrome to the real Robinhood website:
-1. Chrome opens to robinhood.com/login
+Or with a specific browser (e.g. Brave on macOS):
+```bash
+bunx robinhood-for-agents login --chrome "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser"
+```
+On macOS, Brave and Chrome are auto-detected if installed. You can also set `BROWSER_PATH` to a browser executable path.
+
+A Chromium-based browser opens to the real Robinhood website:
+1. Browser opens to robinhood.com/login
 2. User enters email and password
 3. Robinhood handles MFA natively (push notification, SMS, etc.)
 4. Token captured automatically and saved securely
-5. Chrome closes when login is complete
+5. Browser closes when login is complete
 
 ### Step 3: Verify
 ```bash
@@ -41,5 +47,5 @@ After successful login, **always** remind the user:
 
 ## Notes
 - No credentials (username/password) pass through the tool layer — login happens on the real Robinhood website
-- Requires Google Chrome installed on the system
+- Requires a Chromium-based browser (Chrome, Brave, or path via `BROWSER_PATH` / `--chrome`)
 - Tokens expire after ~24h; the client auto-refreshes before requiring re-auth

--- a/src/server/browser-auth.ts
+++ b/src/server/browser-auth.ts
@@ -1,33 +1,76 @@
 /**
  * Browser-based Robinhood authentication using Playwright.
  *
- * Opens system Chrome to robinhood.com/login. The user logs in normally
- * (including MFA via push, SMS, etc.). Playwright intercepts the OAuth
- * token response and stores it via the encrypted token store.
+ * Opens a Chromium-based browser (Chrome, Brave, or custom path) to
+ * robinhood.com/login. The user logs in normally (including MFA via push,
+ * SMS, etc.). Playwright intercepts the OAuth token response and stores
+ * it via the encrypted token store.
  */
 
+import { existsSync } from "node:fs";
 import type { Browser } from "playwright-core";
 import { chromium, type Request, type Response } from "playwright-core";
 import { getClient } from "../client/index.js";
 import { saveTokens } from "../client/token-store.js";
+import { getAccountHint } from "./tools/_helpers.js";
 
 const LOGIN_URL = "https://robinhood.com/login";
 const TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Paths to common Chromium-based browsers on macOS (Brave first, then Chrome). */
+const MACOS_BROWSER_PATHS = [
+  "/Applications/Brave Browser.app/Contents/MacOS/Brave Browser",
+  "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+  "/Applications/Chromium.app/Contents/MacOS/Chromium",
+] as const;
+
+export interface BrowserLoginOptions {
+  /** Path to browser executable (e.g. Brave or Chrome). If not set, uses BROWSER_PATH env or auto-detects on macOS. */
+  executablePath?: string;
+}
 
 export interface BrowserLoginResult {
   status: "logged_in";
   account_hint: string;
 }
 
-export async function browserLogin(): Promise<BrowserLoginResult> {
+/** Format a login success message for CLI/TUI display. */
+export function formatLoginSuccessMessage(result: BrowserLoginResult): string {
+  return `Logged in${result.account_hint ? ` (account ${result.account_hint})` : ""}.`;
+}
+
+/**
+ * Resolve browser executable: env BROWSER_PATH, then on macOS check Brave/Chrome/Chromium, else undefined (use channel).
+ */
+export function resolveBrowserExecutable(): string | undefined {
+  const fromEnv = process.env.BROWSER_PATH?.trim();
+  if (fromEnv && existsSync(fromEnv)) return fromEnv;
+
+  if (process.platform === "darwin") {
+    for (const p of MACOS_BROWSER_PATHS) {
+      if (existsSync(p)) return p;
+    }
+  }
+
+  return undefined;
+}
+
+export async function browserLogin(options?: BrowserLoginOptions): Promise<BrowserLoginResult> {
+  const executablePath = options?.executablePath?.trim() || resolveBrowserExecutable();
+
+  const launchOptions = {
+    headless: false,
+    ...(executablePath ? { executablePath } : { channel: "chrome" as const }),
+  };
+
   let browser: Browser;
   try {
-    browser = await chromium.launch({
-      channel: "chrome",
-      headless: false,
-    });
+    browser = await chromium.launch(launchOptions);
   } catch {
-    throw new Error("Chrome not found. Install Google Chrome to use browser-based login.");
+    const hint = executablePath
+      ? ` (${executablePath})`
+      : ". Set BROWSER_PATH or use --chrome /path/to/browser, or install Google Chrome";
+    throw new Error(`Browser not found${hint}.`);
   }
 
   const context = await browser.newContext();
@@ -117,16 +160,7 @@ export async function browserLogin(): Promise<BrowserLoginResult> {
     const rh = getClient();
     await rh.restoreSession();
 
-    // Get account hint
-    let accountHint = "";
-    try {
-      const profile = await rh.getAccountProfile();
-      const acct = profile.account_number ?? "";
-      accountHint = acct.length >= 4 ? `...${acct.slice(-4)}` : acct;
-    } catch {
-      // Skip
-    }
-
+    const accountHint = await getAccountHint(rh);
     return { status: "logged_in", account_hint: accountHint };
   } finally {
     await browser.close().catch(() => {});

--- a/src/server/cli/onboard.ts
+++ b/src/server/cli/onboard.ts
@@ -137,7 +137,8 @@ export async function onboard(preselectedAgent?: AgentId): Promise<void> {
 
   if (!skipLogin) {
     const wantLogin = await p.confirm({
-      message: "Log in to Robinhood? Chrome will open to robinhood.com/login",
+      message:
+        "Log in to Robinhood? A browser (Brave/Chrome or BROWSER_PATH) will open to robinhood.com/login",
       initialValue: true,
     });
 
@@ -145,11 +146,9 @@ export async function onboard(preselectedAgent?: AgentId): Promise<void> {
       const loginSpinner = p.spinner();
       loginSpinner.start("Waiting for login...");
       try {
-        const { browserLogin } = await import("../browser-auth.js");
+        const { browserLogin, formatLoginSuccessMessage } = await import("../browser-auth.js");
         const result = await browserLogin();
-        loginSpinner.stop(
-          `Logged in${result.account_hint ? ` (account ${result.account_hint})` : ""}.`,
-        );
+        loginSpinner.stop(formatLoginSuccessMessage(result));
       } catch (err) {
         loginSpinner.stop("Login failed.");
         p.log.error(err instanceof Error ? err.message : "Unknown error during login");

--- a/src/server/tools/_helpers.ts
+++ b/src/server/tools/_helpers.ts
@@ -18,6 +18,19 @@ export function getRh() {
   return getClient();
 }
 
+/** Returns a short account hint (e.g. "...4521") for display. */
+export async function getAccountHint(rh: {
+  getAccountProfile(): Promise<{ account_number?: string }>;
+}): Promise<string> {
+  try {
+    const profile = await rh.getAccountProfile();
+    const acct = profile.account_number ?? "";
+    return acct.length >= 4 ? `...${acct.slice(-4)}` : acct;
+  } catch {
+    return "";
+  }
+}
+
 export async function getAuthenticatedRh() {
   const rh = getClient();
   if (!rh.isLoggedIn) {

--- a/src/server/tools/auth.ts
+++ b/src/server/tools/auth.ts
@@ -2,12 +2,12 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { browserLogin } from "../browser-auth.js";
-import { getRh, text, textError } from "./_helpers.js";
+import { getAccountHint, getRh, text, textError } from "./_helpers.js";
 
 export function registerAuthTools(server: McpServer): void {
   server.tool(
     "robinhood_browser_login",
-    "Authenticate with Robinhood by opening Chrome to the real login page. The user logs in normally (including MFA). This is the only way to authenticate — no credentials are passed through the tool.",
+    "Authenticate with Robinhood by opening a Chromium-based browser (Brave/Chrome auto-detected on macOS, or BROWSER_PATH) to the real login page. The user logs in normally (including MFA). This is the only way to authenticate — no credentials are passed through the tool.",
     {},
     async () => {
       try {
@@ -29,14 +29,7 @@ export function registerAuthTools(server: McpServer): void {
         const rh = getRh();
         try {
           const result = await rh.restoreSession();
-          let accountHint = "";
-          try {
-            const profile = await rh.getAccountProfile();
-            const acct = profile.account_number ?? "";
-            accountHint = acct.length >= 4 ? `...${acct.slice(-4)}` : acct;
-          } catch {
-            // Skip
-          }
+          const accountHint = await getAccountHint(rh);
           return text({
             status: "logged_in",
             method: result.method,


### PR DESCRIPTION
## Summary

Add support for Chrome-based browsers (Brave, Chrome, custom path) for Robinhood browser login.

Auto-detect on macOS: Tries Brave, then Google Chrome, then Chromium in /Applications when no path is given.
BROWSER_PATH env: Optional path to the browser executable (e.g. Brave) used by both the CLI and MCP robinhood_browser_login tool.
login --chrome / --browser: New robinhood-for-agents login subcommand with --chrome <path> or --browser <path> to use a specific browser.
Refactors: Shared getAccountHint() in server tools helpers; formatLoginSuccessMessage() for CLI/onboard; parseBrowserPath() for CLI args; single launchOptions object in browser-auth. 
Docs/skills updated: CLAUDE.md, setup.md, reference.md, auth tool description, onboard prompt.

## Safety Checklist

- [x] Does not expose fund transfer or bank operations
- [x] Does not enable bulk operations without safeguards
- [x] Order-related changes require explicit parameters (no dangerous defaults) — N/A (auth/browser only)
- [x] ACCESS_CONTROLS.md updated if adding new operations — N/A (no new operations)

## Testing

- [x] `npx vitest run` passes
- [x] `bun run typecheck` passes
- [x] `bun run check` passes
- [ ] New tests added for new functionality — existing auth tests cover flow; browser resolution not covered by new tests