### PR TITLE
Fix package runtime entrypoints

### DIFF
--- a/__tests__/package-exports.test.ts
+++ b/__tests__/package-exports.test.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+type PackageExport = {
+  default?: string;
+  import?: string;
+  types?: string;
+};
+
+type PackageJson = {
+  bin?: Record<string, string>;
+  exports?: Record<string, PackageExport>;
+  files?: string[];
+  scripts?: Record<string, string>;
+};
+
+const packageJson = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+) as PackageJson;
+
+describe("package publish entrypoints", () => {
+  it("exports compiled JavaScript and declaration files", () => {
+    expect(packageJson.exports?.["."]).toEqual({
+      types: "./dist/src/index.d.ts",
+      import: "./dist/src/index.js",
+      default: "./dist/src/index.js",
+    });
+    expect(packageJson.exports?.["./client"]).toEqual({
+      types: "./dist/src/client/index.d.ts",
+      import: "./dist/src/client/index.js",
+      default: "./dist/src/client/index.js",
+    });
+  });
+
+  it("publishes built output instead of TypeScript source entrypoints", () => {
+    expect(packageJson.scripts?.build).toBe("tsc -p tsconfig.build.json");
+    expect(packageJson.scripts?.prepack).toBe("npm run build");
+    expect(packageJson.files).toEqual(["dist", "skills"]);
+    expect(packageJson.bin?.["robinhood-for-agents"]).toBe("./dist/bin/robinhood-for-agents.js");
+  });
+});

--- a/__tests__/server/install-mcp.test.ts
+++ b/__tests__/server/install-mcp.test.ts
@@ -1,5 +1,5 @@
-import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
+import { binPath } from "../../src/server/cli/paths.js";
 
 const execFileSyncMock = vi.fn();
 vi.mock("node:child_process", () => ({ execFileSync: execFileSyncMock }));
@@ -66,7 +66,6 @@ describe("installMcp", () => {
 
     const addCall = execFileSyncMock.mock.calls[1] as unknown[];
     const args = addCall[1] as string[];
-    const expectedBinPath = resolve(import.meta.dirname, "../../bin/robinhood-for-agents.ts");
-    expect(args).toContain(expectedBinPath);
+    expect(args).toContain(binPath());
   });
 });

--- a/__tests__/server/paths.test.ts
+++ b/__tests__/server/paths.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { binPath, packageRoot, skillsDir } from "../../src/server/cli/paths.js";
+
+describe("cli paths", () => {
+  const tempDirs: string[] = [];
+
+  function makePackageRoot(): string {
+    const root = mkdtempSync(join(tmpdir(), "rh-paths-test-"));
+    tempDirs.push(root);
+    writeFileSync(join(root, "package.json"), "{}\n");
+    mkdirSync(join(root, "bin"), { recursive: true });
+    mkdirSync(join(root, "skills"), { recursive: true });
+    writeFileSync(join(root, "bin", "robinhood-for-agents.ts"), "");
+    return root;
+  }
+
+  afterEach(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tempDirs.length = 0;
+  });
+
+  it("finds the package root from nested source or dist paths", () => {
+    const root = makePackageRoot();
+    const sourceCliDir = join(root, "src", "server", "cli");
+    const distCliDir = join(root, "dist", "src", "server", "cli");
+    mkdirSync(sourceCliDir, { recursive: true });
+    mkdirSync(distCliDir, { recursive: true });
+
+    expect(packageRoot(sourceCliDir)).toBe(root);
+    expect(packageRoot(distCliDir)).toBe(root);
+  });
+
+  it("resolves skills from the package root", () => {
+    const root = makePackageRoot();
+
+    expect(skillsDir(root)).toBe(join(root, "skills"));
+    expect(existsSync(skillsDir(root))).toBe(true);
+  });
+
+  it("uses the source TypeScript bin before the package is built", () => {
+    const root = makePackageRoot();
+
+    expect(binPath(root)).toBe(join(root, "bin", "robinhood-for-agents.ts"));
+  });
+
+  it("uses the compiled JavaScript bin when the package has been built", () => {
+    const root = makePackageRoot();
+    const compiledBin = join(root, "dist", "bin", "robinhood-for-agents.js");
+    mkdirSync(join(root, "dist", "bin"), { recursive: true });
+    writeFileSync(compiledBin, "");
+
+    expect(binPath(root)).toBe(compiledBin);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -25,20 +25,24 @@
   "engines": {
     "bun": ">=1.3.0"
   },
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
   "bin": {
-    "robinhood-for-agents": "./bin/robinhood-for-agents.ts"
+    "robinhood-for-agents": "./dist/bin/robinhood-for-agents.js"
   },
   "exports": {
     ".": {
-      "types": "./src/index.ts",
-      "default": "./src/index.ts"
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "default": "./dist/src/index.js"
     },
     "./client": {
-      "types": "./src/client/index.ts",
-      "default": "./src/client/index.ts"
+      "types": "./dist/src/client/index.d.ts",
+      "import": "./dist/src/client/index.js",
+      "default": "./dist/src/client/index.js"
     }
   },
-  "files": ["src", "bin", "skills"],
+  "files": ["dist", "skills"],
   "dependencies": {
     "@clack/prompts": "^1.1.0",
     "@modelcontextprotocol/sdk": "^1.12.0",
@@ -52,6 +56,8 @@
     "vitest": "^4.0.18"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "prepack": "npm run build",
     "typecheck": "tsc --noEmit",
     "check": "biome check .",
     "check:fix": "biome check --write .",

--- a/src/server/cli/install-mcp.ts
+++ b/src/server/cli/install-mcp.ts
@@ -1,11 +1,11 @@
-import { resolve } from "node:path";
 import { claudeCode } from "./agents/claude-code.js";
+import { binPath } from "./paths.js";
 
 export function installMcp(): void {
-  const binPath = resolve(import.meta.dirname, "../../../bin/robinhood-for-agents.ts");
+  const entry = binPath();
 
-  claudeCode.installMcp?.(binPath);
+  claudeCode.installMcp?.(entry);
 
   console.log(`  MCP server added via 'claude mcp add -s user'`);
-  console.log(`  Command: bun run ${binPath}`);
+  console.log(`  Command: bun run ${entry}`);
 }

--- a/src/server/cli/install-skills.ts
+++ b/src/server/cli/install-skills.ts
@@ -1,8 +1,9 @@
 import { cpSync, existsSync, mkdirSync, readdirSync } from "node:fs";
-import { join, resolve } from "node:path";
+import { join } from "node:path";
+import { skillsDir } from "./paths.js";
 
 export function installSkills(targetDir: string): void {
-  const skillsSource = resolve(import.meta.dirname, "../../../skills");
+  const skillsSource = skillsDir();
 
   if (!existsSync(skillsSource)) {
     console.error(`Skills directory not found: ${skillsSource}`);

--- a/src/server/cli/onboard.ts
+++ b/src/server/cli/onboard.ts
@@ -1,5 +1,4 @@
 import { execSync } from "node:child_process";
-import { resolve } from "node:path";
 import * as p from "@clack/prompts";
 import { loadTokens } from "../../client/token-store.js";
 import { claudeCode } from "./agents/claude-code.js";
@@ -9,6 +8,7 @@ import type { AgentId, AgentMeta } from "./agents/types.js";
 import { AGENTS } from "./agents/types.js";
 import { isCliAvailable } from "./detect.js";
 import { installWorkspaceDep } from "./install-workspace-dep.js";
+import { binPath, skillsDir } from "./paths.js";
 
 const agentMap: Record<AgentId, AgentMeta> = {
   "claude-code": claudeCode,
@@ -86,13 +86,12 @@ export async function onboard(preselectedAgent?: AgentId): Promise<void> {
   }
 
   // --- Install MCP ---
-  const binPath = resolve(import.meta.dirname, "../../../bin/robinhood-for-agents.ts");
-
   if (agent.installMcp) {
+    const entry = binPath();
     const mcpSpinner = p.spinner();
     mcpSpinner.start("Installing MCP config...");
     try {
-      agent.installMcp(binPath);
+      agent.installMcp(entry);
       mcpSpinner.stop("MCP server registered.");
     } catch (err) {
       mcpSpinner.stop("MCP installation failed.");
@@ -103,7 +102,7 @@ export async function onboard(preselectedAgent?: AgentId): Promise<void> {
 
   // --- Install skills ---
   if (agent.supportsSkills && agent.installSkills) {
-    const skillsSource = resolve(import.meta.dirname, "../../../skills");
+    const skillsSource = skillsDir();
     const skillsSpinner = p.spinner();
     skillsSpinner.start("Installing skills...");
     try {

--- a/src/server/cli/paths.ts
+++ b/src/server/cli/paths.ts
@@ -1,0 +1,25 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export function packageRoot(startDir = import.meta.dirname): string {
+  let dir = startDir;
+
+  while (!existsSync(join(dir, "package.json"))) {
+    const parent = dirname(dir);
+    if (parent === dir) {
+      throw new Error("Could not locate package root");
+    }
+    dir = parent;
+  }
+
+  return dir;
+}
+
+export function skillsDir(root = packageRoot()): string {
+  return join(root, "skills");
+}
+
+export function binPath(root = packageRoot()): string {
+  const compiled = join(root, "dist", "bin", "robinhood-for-agents.js");
+  return existsSync(compiled) ? compiled : join(root, "bin", "robinhood-for-agents.ts");
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "bin/**/*.ts"],
+  "exclude": ["__tests__/**"]
+}


### PR DESCRIPTION
## Summary

- Compile TypeScript sources to `dist/` before packaging.
- Point package `main`, `types`, `bin`, and `exports` at compiled JavaScript and declaration files.
- Publish `dist` plus existing skills instead of exposing TypeScript source files as runtime entrypoints.
- Add a package-entrypoint regression test covering the root export, `./client` export, bin target, build script, and published files list.

## Why

`robinhood-for-agents@0.7.0` currently exports `./src/index.ts` and `./src/client/index.ts` directly. A plain Node ESM consumer then asks Node to load TypeScript source from `node_modules`, which fails before any Robinhood credentials, login, or runtime setup is involved.

This keeps the Bun-based CLI/runtime boundary intact while making the published npm package entrypoints resolve to built JavaScript and `.d.ts` files.

Fixes #15.

## Validation

- `npx vitest run __tests__/package-exports.test.ts` failed before the package metadata/build changes and passes after them.
- `npm run typecheck`
- `npm run check` (passes with existing Biome schema/deprecation info only)
- `npm test`
- `npm run build`
- `npm pack --json --pack-destination /tmp/robinhood-for-agents-pack`
- Installed the generated tarball into a clean temporary ESM consumer and verified:
  - `import("robinhood-for-agents")`
  - `import("robinhood-for-agents/client")`
