### PR TITLE
fix: stop redacting account_number, which broke multi-account flows (#14)

### DIFF
--- a/__tests__/redact.test.ts
+++ b/__tests__/redact.test.ts
@@ -48,6 +48,11 @@ describe("redactTokens", () => {
     expect(redactTokens(input)).toBe(input);
   });
 
+  it("does not redact account_number (needed for multi-account flows)", () => {
+    const input = '{"account_number":"1AB23456","type":"individual"}';
+    expect(redactTokens(input)).toBe(input);
+  });
+
   it("does not redact short dotted strings", () => {
     const input = "version 1.2.3";
     expect(redactTokens(input)).toBe(input);
@@ -89,5 +94,12 @@ describe("scrubSensitiveKeys", () => {
   it("passes through objects with no sensitive keys", () => {
     const obj = { symbol: "AAPL", price: 150 };
     expect(scrubSensitiveKeys(obj)).toEqual(obj);
+  });
+
+  it("does not redact account_number (needed for multi-account flows)", () => {
+    const obj = { account_number: "1AB23456", type: "individual" };
+    const result = scrubSensitiveKeys(obj);
+    expect(result.account_number).toBe("1AB23456");
+    expect(result.type).toBe("individual");
   });
 });

--- a/__tests__/server/tools.test.ts
+++ b/__tests__/server/tools.test.ts
@@ -149,7 +149,7 @@ describe("Tool handlers return MCP content format", () => {
     expect(accountsData.accounts).toEqual([
       {
         url: "https://api.robinhood.com/accounts/ABC123/",
-        account_number: "[REDACTED]",
+        account_number: "ABC123",
         type: "cash",
       },
     ]);

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -12,7 +12,7 @@ const BEARER_HEADER_PATTERN = /\bBearer\s+[A-Za-z0-9_.-]{10,}\b/gi;
 // Matches values of known sensitive keys in JSON-serialized strings.
 // e.g. "access_token":"some-value" → "access_token":"[REDACTED]"
 const SENSITIVE_KEY_PATTERN =
-  /"(access_token|refresh_token|device_token|bearer_token|authorization|password|secret|account_number)":\s*"([^"]*)"/gi;
+  /"(access_token|refresh_token|device_token|bearer_token|authorization|password|secret)":\s*"([^"]*)"/gi;
 
 /** Redact JWT tokens and known sensitive key values from a string. */
 export function redactTokens(input: string): string {
@@ -31,7 +31,6 @@ const SENSITIVE_KEYS = new Set([
   "token",
   "password",
   "secret",
-  "account_number",
 ]);
 
 /** Deep-clone an object, replacing known sensitive key values with [REDACTED]. */


### PR DESCRIPTION
Fixes #14.

## Problem

`src/redact.ts` listed `account_number` in both `SENSITIVE_KEY_PATTERN` and `SENSITIVE_KEYS`. Every MCP tool response is wrapped by `_helpers.ts` → `text()` → `redactTokens(...)`, so every `account_number` was replaced with `[REDACTED]`. This broke multi-account flows:

- `robinhood_get_accounts` returned `[REDACTED]` for every account.
- Feeding one back into `robinhood_get_portfolio({ account_number })` produced `GET /positions/?…&account_number=%5BREDACTED%5D` → `HTTP 404: Not found.`

## Fix

Drop `account_number` from both the regex and the key set. A 9-digit brokerage account ID is not usable without an authenticated session, and the sibling `url` field already exposes it unredacted — so the redaction provided no protection while breaking the tools. Tokens, passwords, and secrets remain redacted.

## Tests

- Added regression tests for `redactTokens` and `scrubSensitiveKeys` asserting `account_number` is preserved (written test-first, watched them fail, then fixed).
- Corrected `__tests__/server/tools.test.ts`, which had encoded the buggy `account_number: "[REDACTED]"` expectation.
- Full suite: 173 passed. `typecheck` and `biome check` clean.

## Verification

Validated end-to-end against a live multi-account login:

| | Before | After |
|---|---|---|
| `get_accounts` | every `account_number` → `[REDACTED]` | real IDs returned |
| `get_portfolio({account_number})` | `HTTP 404: Not found.` | succeeds per account |

🤖 Generated with [Claude Code](https://claude.com/claude-code)