### PR TITLE
docs: catch up skills/docs to PR #21's schema accuracy pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ AI-native Robinhood trading interface — MCP server + TypeScript client library
 - **Runtime**: Bun
 - **Language**: TypeScript (strict mode, ESM-only)
 - **MCP SDK**: `@modelcontextprotocol/sdk` v1.12+ (McpServer + StdioServerTransport)
-- **Validation**: Zod v3.24 (API responses + MCP tool schemas)
+- **Validation**: Zod v3.24 — types API response shapes (cast, not runtime-parsed) + runtime-validates MCP tool-call params
 - **Testing**: Vitest (not `bun test` — module isolation matters)
 - **Linting**: Biome v2
 - **Browser Auth**: playwright-core (drives system Chrome, no bundled browser)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -44,7 +44,7 @@
 | **Bun** | Native TS execution, fast startup, built-in fetch |
 | **ESM-only** | Bun is ESM-native, no CJS needed |
 | **@modelcontextprotocol/sdk** | Official MCP SDK, StdioServerTransport for agent compatibility |
-| **Zod v3.24** | Runtime validation of API responses + MCP tool parameter schemas |
+| **Zod v3.24** | Types API response shapes (client casts, not runtime-parsed) + runtime-validates MCP tool parameters |
 | **Vitest** | Fast TS-native testing, correct module isolation via `vi.mock()` |
 | **Biome v2** | All-in-one lint + format, 10-25x faster than ESLint |
 | **Bun.secrets** | OS keychain access (macOS Keychain Services, Linux libsecret) |
@@ -413,5 +413,5 @@ Stock order payloads include `order_form_version: 7` (required by the Robinhood 
 | **No phoenix.robinhood.com** | TLS handshake fails. `api.robinhood.com` has equivalent data. |
 | **Unified order methods** | `orderStock()` with optional params vs 10 separate `orderBuyMarket()` etc. |
 | **Vitest over bun test** | Proper module isolation via worker processes. Critical for mocking. |
-| **Zod schemas** | Runtime validation of all API responses -- Python version lacked this. |
+| **Zod schemas** | Type API response shapes for TS consumers -- the client casts rather than `.parse()`s, so zero runtime overhead (caveat: an under-declared schema silently hides real response fields from the TS types without erroring). Opt-in `parseOne`/`parseArray` helpers in `src/client/http.ts` runtime-validate when a caller wants it. MCP tool-call parameters, by contrast, ARE runtime-validated via the same library. |
 | **ESM-only** | Bun is ESM-native, no CJS compatibility needed. |

--- a/skills/robinhood-for-agents/SKILL.md
+++ b/skills/robinhood-for-agents/SKILL.md
@@ -77,7 +77,7 @@ If it throws, follow [setup.md](setup.md) to authenticate.
 | `getCryptoPositions()` | Crypto | Crypto holdings |
 | `getCryptoQuote(symbol)` | Crypto | Current crypto price |
 | `getQuotes(symbols)` | Research | Stock quotes (price, bid/ask, P/E) |
-| `getFundamentals(symbols)` | Research | Market cap, 52-week range, sector |
+| `getFundamentals(symbols)` | Research | Market cap, valuation, dividends, 52-week range, sector |
 | `getNews(symbol)` | Research | Recent news articles |
 | `getRatings(symbol)` | Research | Analyst buy/hold/sell ratings |
 | `getEarnings(symbol)` | Research | Quarterly EPS history |

--- a/skills/robinhood-for-agents/client-api.md
+++ b/skills/robinhood-for-agents/client-api.md
@@ -70,10 +70,10 @@ const btc = await rh.getCryptoQuote("BTC");
 ## Research Methods
 
 ### `getQuotes(symbols): Promise<Quote[]>`
-Accepts single symbol or array. Returns `last_trade_price`, `bid_price`, `ask_price`, `previous_close`, `pe_ratio`.
+Accepts single symbol or array. Returns `last_trade_price`, `bid_price`, `ask_price`, `bid_size`, `ask_size`, `previous_close`, `pe_ratio`, `state` (trading status).
 
 ### `getFundamentals(symbols): Promise<Fundamental[]>`
-Returns `market_cap`, `pe_ratio`, `dividend_yield`, `high_52_weeks`, `low_52_weeks`, `description`, `ceo`, `sector`.
+Returns `market_cap`, `pe_ratio`, `pb_ratio`, `float`, `dividend_yield`, `high_52_weeks`, `low_52_weeks`, `description`, `ceo`, `sector`, plus a full dividend schedule (`dividend_per_share`, `ex_dividend_date`, `payable_date`, `distribution_frequency`).
 
 ### `getStockHistoricals(symbols, opts?): Promise<StockHistorical[]>`
 ```typescript
@@ -84,6 +84,7 @@ const hist = await rh.getStockHistoricals("AAPL", { interval: "day", span: "year
 ### `getNews(symbol): Promise<News[]>`
 ### `getRatings(symbol): Promise<Rating>`
 ### `getEarnings(symbol): Promise<Earnings[]>`
+EPS is nested under `eps` (`eps.estimate`, `eps.actual`) — not flat top-level fields (assuming flat returns `undefined`). Also includes `report` (date/timing) and `call` (datetime, replay_url).
 ### `findInstruments(query): Promise<Instrument[]>`
 
 ## Options Methods

--- a/skills/robinhood-for-agents/options.md
+++ b/skills/robinhood-for-agents/options.md
@@ -72,7 +72,7 @@ const spx = await rh.getIndexValue("SPX");
 
 **Option instrument**: `strike_price`, `expiration_date`, `type` (call/put), `state`, `tradability`
 
-**Market data (greeks)**: `adjusted_mark_price`, `delta`, `gamma`, `theta`, `vega`, `rho`, `implied_volatility`, `open_interest`, `volume`, `chance_of_profit_long`, `chance_of_profit_short`
+**Market data (greeks)**: `adjusted_mark_price`, `delta`, `gamma`, `theta`, `vega`, `rho`, `implied_volatility`, `open_interest`, `volume`, `bid_size`, `ask_size`, `chance_of_profit_long`, `chance_of_profit_short`
 
 ## Placing Option Orders
 Before placing, get accounts and ask which to use. See [trade.md](trade.md) for the full option order flow.

--- a/skills/robinhood-for-agents/reference.md
+++ b/skills/robinhood-for-agents/reference.md
@@ -88,7 +88,7 @@ Get quote and fundamentals. Also works for index symbols (SPX, NDX, VIX, RUT, XS
 {
   "AAPL": {
     "quote": { "last_trade_price": "150.00", "bid_price": "149.90", "ask_price": "150.10", "previous_close": "148.00", "pe_ratio": "25.5" },
-    "fundamentals": { "market_cap": "2500000000000", "dividend_yield": "0.55", "high_52_weeks": "180.00", "low_52_weeks": "120.00" }
+    "fundamentals": { "market_cap": "2500000000000", "pb_ratio": "45.20", "dividend_yield": "0.55", "high_52_weeks": "180.00", "low_52_weeks": "120.00" }
   }
 }
 ```

--- a/skills/robinhood-for-agents/research.md
+++ b/skills/robinhood-for-agents/research.md
@@ -26,7 +26,7 @@ Index symbols (SPX, NDX, VIX, RUT, XSP) also work with `getQuotes()` — returns
 
 ## Key Data Fields
 - **Quote**: `last_trade_price`, `bid_price`, `ask_price`, `previous_close`, `pe_ratio`
-- **Fundamentals**: `market_cap`, `pe_ratio`, `dividend_yield`, `high_52_weeks`, `low_52_weeks`, `description`, `ceo`, `sector`
+- **Fundamentals**: `market_cap`, `pe_ratio`, `pb_ratio`, `float`, `dividend_yield`, dividend schedule (`dividend_per_share`, `ex_dividend_date`), `high_52_weeks`, `low_52_weeks`, `description`, `ceo`, `sector`
 - **Ratings**: `summary.num_buy_ratings`, `summary.num_hold_ratings`, `summary.num_sell_ratings`
 - **Earnings**: `eps.estimate`, `eps.actual`, `year`, `quarter`
 - **Historicals**: Array of `{ begins_at, open_price, close_price, high_price, low_price, volume }`
@@ -34,7 +34,7 @@ Index symbols (SPX, NDX, VIX, RUT, XSP) also work with `getQuotes()` — returns
 ## Output Structure
 1. **Company Overview**: Name, sector, industry, market cap, description
 2. **Price Data**: Current price, 52-week range, position within range
-3. **Valuation**: P/E ratio, dividend yield
+3. **Valuation**: P/E ratio, P/B ratio, dividend yield
 4. **Analyst Ratings**: Buy/Hold/Sell consensus
 5. **Recent Earnings**: Last 4 quarters EPS (estimate vs actual)
 6. **News**: Top 5 recent headlines


### PR DESCRIPTION
## What

Follow-up to #21, which widened several Zod schemas in `src/client/types.ts` against live API responses but didn't touch documentation. This surfaces the newly-typed, agent-useful fields in the relevant skill docs and corrects a pre-existing inaccuracy about how Zod is used.

## Changes

- **`skills/robinhood-for-agents/client-api.md`** — `getQuotes`/`getFundamentals` descriptions now mention the new fields (`bid_size`/`ask_size`/`state`, `pb_ratio`/`float`/dividend schedule); `getEarnings` gained a description flagging that EPS is nested under `eps.estimate`/`eps.actual` (a flat-field assumption silently returns `undefined`).
- **`skills/robinhood-for-agents/research.md`** — Fundamentals field list and the Valuation output step now include P/B ratio, float, and dividend schedule.
- **`skills/robinhood-for-agents/options.md`** — added `bid_size`/`ask_size` to the market-data field list (liquidity signal for options screening).
- **`skills/robinhood-for-agents/SKILL.md`** / **`reference.md`** — small widened descriptions/examples.
- **`CLAUDE.md`** / **`docs/ARCHITECTURE.md`** — fixed an inaccuracy: both docs claimed Zod provides "runtime validation of API responses," but the client actually **casts** (`as X[]`) rather than `.parse()`s (verified: `parseOne`/`parseArray` helpers exist in `src/client/http.ts` but are never called in `client.ts`). Reworded to correctly state Zod types the response shapes (cast, not runtime-parsed) while separately, genuinely runtime-validating MCP tool-call parameters.

Docs-only change, no code touched.

## Test plan
- [x] Read every field name against current `src/client/types.ts` to confirm it exists
- [x] Diffed each edited file to confirm formatting/style untouched outside intended lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)