### PR TITLE
feat: proactive token renewal, rotation recovery, honest session checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-24
+
+### Added
+
+- **Proactive token renewal** — `TokenData` gained an optional `expires_at` (unix seconds) and a new exported `deriveExpiresAt(accessToken, {expiresIn, issuedAt})` helper that prefers the JWT `exp` claim and falls back to `issuedAt + expires_in`. `RobinhoodSession.ensureFreshToken` is a new pre-request hook that renews the access token 24h before expiry (`REFRESH_SKEW_SEC`) instead of waiting for a 401 — refresh tokens are single-use and rotate on every grant, so it is the chain lapsing while the client is idle, not the access token expiring, that forces a browser re-login. `restoreSession()` backfills `expires_at` for entries persisted before the field existed, so existing logins get proactive renewal without re-authenticating; the field is optional purely for that back-compat.
+- **Cross-process token adoption** — when a refresh POST is rejected, `adoptFromStore()` re-reads the `TokenStore` and adopts a token another process may have already persisted, rather than failing while a valid credential sits in the store. Robinhood enforces single-use refresh-token rotation with no cross-process lock available, so two clients refreshing concurrently poison the loser; this makes that recoverable, but a single writer per store is still the supported configuration.
+
+### Changed
+
+- **`robinhood_check_session` now probes the API** instead of reporting `logged_in` whenever tokens merely exist. Returns `logged_in` (probe succeeded), `expired` (tokens dead and unrefreshable, with re-login instructions), `unknown` (transient/network failure — deliberately not claimed as expired), or `not_authenticated`.
+- **A 401 surviving the refresh retry raises `TokenExpiredError`** (existing `AuthenticationError` subclass, now actually used) telling the caller to re-authenticate with browser login, instead of a bare `APIError: HTTP 401` that gave no indication a re-login was needed.
+- **Refresh-token save failures are no longer silently swallowed** — they log a `CRITICAL` message to stderr. Under enforced rotation the attempted token is already dead, so a lost save leaves the only copy of the new refresh token in memory and strands the next process start.
+- Documentation corrected throughout: access-token lifetime is **variable** (~6–8.5 days observed), not a fixed ~8.5 days, and refresh is no longer described as 401-only. `docs/DOCKER.md` gains a single-writer warning and a container re-authentication runbook.
+
 ## [1.0.1] - 2026-07-16
 
 ### Fixed
@@ -178,6 +192,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Safety controls: blocked fund transfers, blocked bulk cancels, explicit order parameters
 - Support for Claude Code, Codex, and OpenClaw agents
 
+[1.1.0]: https://github.com/kevin1chun/robinhood-for-agents/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/kevin1chun/robinhood-for-agents/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/kevin1chun/robinhood-for-agents/compare/v0.8.0...v1.0.0
 [0.8.0]: https://github.com/kevin1chun/robinhood-for-agents/compare/v0.7.2...v0.8.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,24 @@ await rh.restoreSession();
 - All methods are `async` (native `fetch` under the hood)
 - Multi-account is first-class: every account-scoped method accepts `accountNumber`
 - Session cached in OS keychain via `Bun.secrets` (macOS Keychain Services) — no plaintext fallback, no tokens on disk
-- Token refresh via `refresh_token` + `device_token` when access token expires
-- Proper exceptions: `AuthenticationError`, `APIError`
+- Token refresh via `refresh_token` + `device_token` — **proactive** (pre-request hook renews 24h before `expires_at`, `REFRESH_SKEW_SEC` in `src/client/auth.ts`) *and* reactive (on 401). Refresh tokens are single-use: every refresh rotates them and kills the previous one
+- Proper exceptions: `AuthenticationError`, `TokenExpiredError` (subclass — a 401 that survived the refresh retry; means re-login), `APIError`
 - **Do NOT use `phoenix.robinhood.com`** — it rejects TLS. Use `api.robinhood.com` endpoints only.
 
 ## Authentication
 - Browser login (`robinhood_browser_login`) opens Google Chrome via playwright-core's `channel: "chrome"` (`src/server/browser-auth.ts`). Chrome must be installed — there is no Brave/Chromium auto-detection, `BROWSER_PATH` override, or `--chrome` CLI flag implemented yet, despite earlier docs suggesting otherwise.
 - Purely passive — Playwright intercepts `/oauth2/token` network traffic, never interacts with the DOM
-- Request body (JSON) → captures `device_token`; Response → captures `access_token` + `refresh_token`
+- Request body (JSON) → captures `device_token`; Response → captures `access_token` + `refresh_token`; `withTimestamp()` stamps `saved_at` and derives `expires_at` from the JWT `exp` claim
 - Tokens stored in OS keychain (`KeychainTokenStore`, default) or encrypted file (`EncryptedFileTokenStore`, for Docker/headless)
-- `restoreSession()` loads tokens from the configured `TokenStore`, sets Bearer auth on the session, and registers automatic 401 token refresh
+- `restoreSession()` loads tokens from the configured `TokenStore`, sets Bearer auth on the session, registers the 401 refresh callback (`session.onUnauthorized`) **and** the pre-request renewal hook (`session.ensureFreshToken`), and backfills `expires_at` on entries persisted before that field existed
+- `TokenData.expires_at` (unix seconds, **optional** for back-compat with already-stored entries) is derived by `deriveExpiresAt()` in `token-store.ts` — JWT `exp` claim first, `issuedAt + expires_in` as fallback
+- Access-token TTL **varies** (~5.9d/6.9d on browser login; 8.5d then 6.1d on refresh grants). **Never hardcode a lifetime** — read `expires_at`
+- Rotation is enforced server-side and single-use: each refresh returns a new `refresh_token` and instantly kills the old one (401 `invalid_grant`); issuing a new token family also revokes the previous *access* token
+- **No cross-process lock.** Two clients refreshing concurrently poison the loser. When a refresh POST is rejected, `adoptFromStore()` re-reads the `TokenStore` and adopts a token another process may have already persisted, instead of giving up
+- A failed token save is **never** swallowed — it logs `CRITICAL` to stderr, because the rotated refresh token then exists only in memory
+- Proactive renewal keeps the chain alive only while the client is *in use*. Idle longer than the refresh-token lifetime → the chain lapses and a new browser login is required
+- A 401 that survives the refresh retry raises `TokenExpiredError` ("re-authenticate with browser login"), not a bare `APIError: HTTP 401` (`src/client/http.ts`)
+- `robinhood_check_session` **probes the API** rather than checking that tokens exist: `logged_in` | `expired` (with re-login instructions) | `unknown` (transient/network) | `not_authenticated`
 - **Docker / headless:** Use `EncryptedFileTokenStore` — set `ROBINHOOD_TOKENS_FILE` and `ROBINHOOD_TOKEN_KEY` env vars. The `onboard` command can export encrypted tokens for container use.
 
 ## Safety Rules

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Robinhood for AI agents — MCP server with 49 tools + TypeScript client library
 - **Unified trading skill** for guided workflows (Claude Code, OpenClaw, [ClawHub](https://clawhub.ai/kevin1chun/robinhood-for-agents))
 - **TypeScript client library** (70+ async methods) for programmatic use
 - **Pluggable token storage** — OS keychain (default) or encrypted file (Docker/headless)
+- **Self-renewing sessions** — tokens refresh ahead of expiry and on 401, so continuous use never needs a re-login
 
 Compatible with **Claude Code**, **Codex**, **OpenClaw**, and any MCP-compatible agent.
 
@@ -123,7 +124,7 @@ From a source checkout, use `"command": "bun", "args": ["run", "/absolute/path/t
 
 ## Authenticate
 
-Start your agent and say "setup robinhood" (or call `robinhood_browser_login` directly). Your browser will open to the real Robinhood login page — log in with your credentials and MFA. The session is cached in your OS keychain and auto-refreshes when the access token expires (via the stored refresh token), so you stay logged in for roughly a week before a browser re-login is needed.
+Start your agent and say "setup robinhood" (or call `robinhood_browser_login` directly). Your browser will open to the real Robinhood login page — log in with your credentials and MFA. The session is cached in your OS keychain and renews itself: the client refreshes the token a day before it expires, and again on any 401. Regular use keeps you logged in indefinitely — a browser re-login is only needed if the client sits unused long enough for the refresh chain to lapse. Ask your agent to run `robinhood_check_session` if you're unsure.
 
 ## MCP Tools (49)
 
@@ -132,7 +133,7 @@ All 49 tools work with every MCP-compatible agent.
 | Tool | Description |
 |------|-------------|
 | `robinhood_browser_login` | Authenticate via Chrome browser |
-| `robinhood_check_session` | Check if cached session is valid |
+| `robinhood_check_session` | Probe the cached session: `logged_in` / `expired` / `unknown` / `not_authenticated` |
 | `robinhood_get_portfolio` | Portfolio: positions, P&L, equity, cash, buying power |
 | `robinhood_get_equity_positions` | Raw equity positions (shares, avg price) |
 | `robinhood_get_equity_tax_lots` | Open tax lots for one equity holding (cost basis, term, open date) |
@@ -264,7 +265,7 @@ services:
       ROBINHOOD_TOKEN_KEY: "${ROBINHOOD_TOKEN_KEY}"
 ```
 
-Token refresh writes re-encrypted tokens back to the file automatically.
+Token refresh writes re-encrypted tokens back to the file automatically — keep the mount read-write. Refresh tokens are single-use: Robinhood kills the old one the instant a new one is issued, so a failed write leaves the only usable copy in memory and the container is stranded after restart. The client logs a `CRITICAL` message to stderr when a save fails — alert on it. See [docs/DOCKER.md](docs/DOCKER.md).
 
 > **Security warning:** The encrypted file protects against casual disk access (image leaks, accidental exposure) but NOT against a malicious agent with shell access in the container — it can read the env var and decrypt. Only run agents you trust. See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model.
 
@@ -288,9 +289,24 @@ Token refresh writes re-encrypted tokens back to the file automatically.
 |---|---|---|
 | `KeychainTokenStore` (default) | Local dev, macOS/Linux with desktop | Nothing — works out of the box |
 | `EncryptedFileTokenStore` | Docker, headless servers, CI, cloud | Set `ROBINHOOD_TOKENS_FILE` + `ROBINHOOD_TOKEN_KEY` env vars |
-| Direct `accessToken` | Serverless, testing, short-lived scripts | Pass `accessToken` to constructor or set `ROBINHOOD_ACCESS_TOKEN` env var |
+| Direct `accessToken` | Serverless, testing, short-lived scripts | Pass `accessToken` to constructor or set `ROBINHOOD_ACCESS_TOKEN` env var — no refresh; expiry raises `TokenExpiredError` |
 
-**How it works**: `restoreSession()` loads tokens from the configured `TokenStore`, injects `Authorization: Bearer` headers directly into API requests, and registers automatic token refresh on 401.
+**How it works**: `restoreSession()` loads tokens from the configured `TokenStore`, injects `Authorization: Bearer` headers directly into API requests, and registers both refresh paths — a pre-request hook that renews the token 24 hours ahead of expiry, and a 401 handler that refreshes and retries once. Sessions saved before token expiry was tracked are backfilled on load, so existing keychain logins get proactive renewal without re-authenticating.
+
+**Session lifetime**: Access-token TTL varies (~6–8.5 days observed — never assume a fixed number). Robinhood rotates refresh tokens on every use: each refresh returns a new one and instantly invalidates the old, so it is the refresh *chain*, not the access token, that keeps you logged in. Regular use keeps the chain alive; a long idle gap lets it lapse.
+
+**When a session expires**: API calls raise `TokenExpiredError` (a subclass of `AuthenticationError`) instead of a bare `HTTP 401`, and `robinhood_check_session` probes the API and reports:
+
+| Status | Meaning |
+|---|---|
+| `logged_in` | Tokens loaded and a live API probe succeeded |
+| `expired` | Tokens no longer work and could not be refreshed — run `robinhood_browser_login` |
+| `unknown` | Probe failed for a transient/network reason; the session may still be fine |
+| `not_authenticated` | No tokens in the store — run `robinhood-for-agents onboard` |
+
+Recovery is always the same: re-run browser login (`robinhood_browser_login`, or say "setup robinhood").
+
+**One writer per token store**: rotation is single-use, so two processes sharing one store can poison each other — the loser refreshes with a token the winner already spent. The client recovers by re-reading the store and adopting whatever the other process persisted, but there is no cross-process lock. Point a single process at a given store where you can.
 
 ```typescript
 import { RobinhoodClient, EncryptedFileTokenStore } from "robinhood-for-agents";
@@ -301,7 +317,7 @@ const client = new RobinhoodClient();
 // Docker/headless: EncryptedFileTokenStore (auto-detected from ROBINHOOD_TOKENS_FILE env)
 const client = new RobinhoodClient({ tokenStore: new EncryptedFileTokenStore() });
 
-// Direct token (no refresh)
+// Direct token (no store, no refresh — expiry surfaces as TokenExpiredError)
 const client = new RobinhoodClient({ accessToken: "..." });
 ```
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,6 @@ This project follows a defense-in-depth approach:
 - Fund transfers and bank operations are permanently blocked
 - Bulk cancel operations are blocked
 - All order placements require explicit parameters with no dangerous defaults
-- Access tokens expire after ~8.5 days and auto-refresh via the stored refresh token
+- Access-token lifetime varies (~6–8.5 days observed) and tokens auto-refresh via the stored refresh token — proactively ~24h before expiry, and on a 401 as a fallback. Refresh tokens are single-use: each renewal issues a new one and immediately invalidates the old, so re-running browser login revokes any previously copied token family
 
 See [docs/SECURITY.md](docs/SECURITY.md) for the full threat model and [docs/ACCESS_CONTROLS.md](docs/ACCESS_CONTROLS.md) for the risk tiers.

--- a/__tests__/client/auth.test.ts
+++ b/__tests__/client/auth.test.ts
@@ -21,6 +21,7 @@ function mockSession(): RobinhoodSession {
     setAccessToken: vi.fn(),
     clearAccessToken: vi.fn(),
     onUnauthorized: null,
+    ensureFreshToken: null,
   } as unknown as RobinhoodSession;
 }
 
@@ -58,6 +59,137 @@ describe("restoreSession (token store)", () => {
     const store = mockStore();
     await restoreSession(session, store);
     expect(session.onUnauthorized).toBeTypeOf("function");
+  });
+});
+
+describe("refresh: rotation and recovery", () => {
+  const originalFetch = globalThis.fetch;
+  const tokenUrl = "https://api.robinhood.com/oauth2/token/";
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function grantResponse(body: Record<string, unknown>) {
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  const rejected = () => new Response(JSON.stringify({ error: "invalid_grant" }), { status: 401 });
+
+  /** Install a typed fetch mock and hand back the spy. */
+  function mockFetch(response: () => Response) {
+    const fn = vi.fn(async () => response());
+    globalThis.fetch = fn as unknown as typeof fetch;
+    return fn;
+  }
+
+  function savedToken(store: TokenStore, call = 0): TokenData {
+    return (store.save as ReturnType<typeof vi.fn>).mock.calls[call]?.[0] as TokenData;
+  }
+
+  it("persists rotated tokens before returning the new access token", async () => {
+    const store = mockStore();
+    const session = mockSession();
+    const fetchSpy = mockFetch(() =>
+      grantResponse({ access_token: "new-access", refresh_token: "rotated", expires_in: 734000 }),
+    );
+
+    await restoreSession(session, store);
+    const token = await session.onUnauthorized?.();
+
+    expect(token).toBe("new-access");
+    expect(store.save).toHaveBeenCalledWith(
+      expect.objectContaining({ access_token: "new-access", refresh_token: "rotated" }),
+    );
+    // Saved before the caller could use it — ordering matters under rotation.
+    const saveOrder = (store.save as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0] ?? 0;
+    expect(saveOrder).toBeGreaterThan(fetchSpy.mock.invocationCallOrder[0] ?? 0);
+  });
+
+  it("records expires_at from the grant so renewal can run ahead of expiry", async () => {
+    const store = mockStore();
+    const session = mockSession();
+    mockFetch(() =>
+      grantResponse({ access_token: "opaque-not-a-jwt", refresh_token: "r2", expires_in: 1000 }),
+    );
+
+    await restoreSession(session, store);
+    await session.onUnauthorized?.();
+
+    const saved = savedToken(store);
+    expect(saved.expires_at).toBeCloseTo(saved.saved_at + 1000, 0);
+  });
+
+  it("adopts a token another process persisted when refresh is rejected", async () => {
+    // Rotation is single-use: if another process refreshed first, ours is dead
+    // but a working token is already sitting in the store.
+    const store = mockStore();
+    (store.load as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(sampleTokens)
+      .mockResolvedValueOnce({ ...sampleTokens, access_token: "fresh", refresh_token: "other" });
+    const session = mockSession();
+    mockFetch(rejected);
+
+    await restoreSession(session, store);
+
+    expect(await session.onUnauthorized?.()).toBe("fresh");
+  });
+
+  it("gives up when the store holds the same token that was just rejected", async () => {
+    const store = mockStore();
+    const session = mockSession();
+    mockFetch(rejected);
+
+    await restoreSession(session, store);
+
+    expect(await session.onUnauthorized?.()).toBeNull();
+  });
+
+  it("registers a pre-request hook that does not renew while expiry is far off", async () => {
+    const store = mockStore({
+      ...sampleTokens,
+      expires_at: Date.now() / 1000 + 30 * 24 * 60 * 60,
+    });
+    const session = mockSession();
+    const fetchSpy = mockFetch(() => grantResponse({ access_token: "unused" }));
+
+    await restoreSession(session, store);
+    expect(session.ensureFreshToken).toBeTypeOf("function");
+
+    await session.ensureFreshToken?.();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("renews through the pre-request hook once inside the skew window", async () => {
+    const store = mockStore({ ...sampleTokens, expires_at: Date.now() / 1000 + 60 });
+    const session = mockSession();
+    const fetchSpy = mockFetch(() =>
+      grantResponse({ access_token: "renewed", refresh_token: "r3" }),
+    );
+
+    await restoreSession(session, store);
+    await session.ensureFreshToken?.();
+
+    expect(fetchSpy).toHaveBeenCalledWith(tokenUrl, expect.objectContaining({ method: "POST" }));
+    expect(session.setAccessToken).toHaveBeenCalledWith("renewed");
+  });
+
+  it("skips renewal when expiry is unknown, leaving it to the 401 path", async () => {
+    const store = mockStore({ ...sampleTokens, access_token: "opaque", expires_at: undefined });
+    const session = mockSession();
+    const fetchSpy = mockFetch(() => grantResponse({ access_token: "unused" }));
+
+    await restoreSession(session, store);
+    await session.ensureFreshToken?.();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
   });
 });
 

--- a/docs/ACCESS_CONTROLS.md
+++ b/docs/ACCESS_CONTROLS.md
@@ -72,7 +72,7 @@ These operations are **never exposed** through MCP tools or skills.
 - Blocked operations are documented as "never use" in reference files
 
 ### General
-- Access tokens last ~8.5 days and auto-refresh on 401 via the stored refresh token
+- Access-token lifetime varies (~6–8.5 days observed). Tokens renew automatically — proactively ~24h before expiry, and on a 401 as a fallback — so a session in regular use stays alive; one left idle past the refresh-token lifetime lapses and needs a new browser login
 - Browser-based login only — no credentials pass through the tool layer
 - Session tokens stored in OS keychain via `Bun.secrets` (macOS Keychain Services) — no plaintext fallback
 - See [SECURITY.md](./SECURITY.md) for the full threat model and deployment tiers

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,9 +58,11 @@
 src/client/                    <- robinhood-for-agents client library
 ├── index.ts                   <- Exports: RobinhoodClient, getClient(), login()
 ├── client.ts                  <- RobinhoodClient class (76 async methods)
-├── auth.ts                    <- Direct auth: TokenStore load, Bearer injection, 401 refresh
+├── auth.ts                    <- Direct auth: TokenStore load, Bearer injection, proactive +
+│                                 401 refresh, rotation recovery (adoptFromStore)
 ├── token-store.ts             <- TokenStore interface + KeychainTokenStore + EncryptedFileTokenStore
-├── session.ts                 <- fetch wrapper (Bearer injection, 401 retry, redirect safety)
+├── session.ts                 <- fetch wrapper (Bearer injection, pre-request ensureFreshToken,
+│                                 401 retry, redirect safety)
 ├── http.ts                    <- GET/POST/DELETE with pagination + trusted-origin validation
 ├── urls.ts                    <- Const URL builders (API_BASE, NUMMUS_BASE, BONFIRE_BASE, DORA_BASE)
 ├── errors.ts                  <- Exception hierarchy
@@ -124,8 +126,10 @@ src/server/                    <- robinhood-for-agents MCP server
 │          └── null → AuthenticationError("No tokens found")             │
 │          │                                                              │
 │          ▼                                                              │
+│  backfill tokens.expires_at if absent (deriveExpiresAt)                │
 │  session.setAccessToken(tokens.access_token)                           │
-│  session.onUnauthorized = refreshCallback(state)                       │
+│  session.onUnauthorized  = refreshCallback(state)      (reactive, 401) │
+│  session.ensureFreshToken = ensureFreshCallback(state) (proactive, 24h)│
 │          │                                                              │
 │          ▼                                                              │
 │  return { status: "logged_in", method: "keychain" | "encrypted_file" }│
@@ -133,7 +137,9 @@ src/server/                    <- robinhood-for-agents MCP server
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-The client constructor accepts `tokenStore` to override the default, or `accessToken` for direct token injection (no store, no refresh).
+`status: "logged_in"` here means only that tokens loaded from the store — it is not a claim that they still work. See [Session Health](#session-health).
+
+The client constructor accepts `tokenStore` to override the default, or `accessToken` for direct token injection (no store, no refresh — neither the proactive hook nor the 401 handler is wired up, so an expired token surfaces as `TokenExpiredError`).
 
 ```typescript
 new RobinhoodClient()                          // auto-detect store
@@ -232,8 +238,15 @@ This design is resilient to Robinhood UI changes -- it doesn't depend on any DOM
 │       3. Generate random key → store in keychain                  │
 │     Use case: Docker, headless servers, CI — no OS keychain.      │
 │                                                                    │
+│  HELPERS                                                           │
+│  ───────                                                           │
+│  deriveExpiresAt(token, {expiresIn, issuedAt})                    │
+│    JWT `exp` claim (authoritative) → else issuedAt + expiresIn    │
+│  withTimestamp(tokens) → stamps saved_at + expires_at             │
+│                                                                    │
 │  TokenData (JSON):                                                 │
-│  {access_token, refresh_token, token_type, device_token, saved_at}│
+│  {access_token, refresh_token, token_type, device_token,          │
+│   account_hint?, saved_at, expires_at?}                           │
 │                                                                    │
 └────────────────────────────────────────────────────────────────────┘
 ```
@@ -249,6 +262,8 @@ This design is resilient to Robinhood UI changes -- it doesn't depend on any DOM
 │         ▼                                                               │
 │  session.get(url, params)                                              │
 │         ├── authHeaders(): inject Authorization: Bearer <token>        │
+│         ├── ensureFreshToken(): renew if within 24h of expires_at,     │
+│         │      then re-stamp the Authorization header                  │
 │         ├── safeFetch(): manual redirect following (trusted origins)   │
 │         │                                                               │
 │         ▼                                                               │
@@ -259,12 +274,62 @@ This design is resilient to Robinhood UI changes -- it doesn't depend on any DOM
 │         └── 401 → fetchWithRetry() calls onUnauthorized()             │
 │                    ├── POST /oauth2/token/ (refresh_token grant)       │
 │                    ├── Update state.tokens + store.save(newTokens)     │
+│                    ├── on rejection: adoptFromStore() re-reads the     │
+│                    │      store in case another process rotated first  │
 │                    ├── session.accessToken = newToken                   │
 │                    └── Retry original request with new Bearer token    │
 │                    (concurrent 401s share a single refresh attempt)    │
+│                    (still 401 → TokenExpiredError, not APIError)       │
 │                                                                         │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
+
+### Token Refresh & Rotation
+
+Robinhood enforces **single-use refresh-token rotation**: each refresh returns a new `refresh_token`, kills the old one immediately (`HTTP 401 invalid_grant` on replay), and revokes the previous access token as well. Access-token TTL is not fixed -- the `expires_in: 734000` (~8.5 days) we send is only sometimes honored, and observed lifetimes run from ~5.9 to ~8.5 days. The client never assumes a duration: `deriveExpiresAt()` reads the JWT `exp` claim off the access token (falling back to `issuedAt + expires_in`) and persists it as `TokenData.expires_at`.
+
+```
+┌─ two refresh paths ───────────────────────────────────────────────┐
+│                                                                    │
+│  PROACTIVE — session.ensureFreshToken (pre-request hook)           │
+│    now >= expires_at - REFRESH_SKEW_SEC (24h) → refresh            │
+│    expires_at undefined (legacy entry, non-JWT) → skip, leave      │
+│      it to the reactive path                                       │
+│                                                                    │
+│  REACTIVE — session.onUnauthorized (401 handler)                   │
+│    fallback when the proactive hook did not fire or failed         │
+│                                                                    │
+│  BOTH → refreshTokens(state)                                       │
+│    POST api.robinhood.com/oauth2/token/                            │
+│      grant_type=refresh_token, client_id=<mobile app>,             │
+│      device_token=<stored>, expires_in=734000                      │
+│    ok     → new {access,refresh} → state.tokens → store.save()     │
+│    not ok → adoptFromStore(): re-read the store; if another        │
+│             process already rotated, adopt its token               │
+│    save fails → CRITICAL to stderr (rotated token is memory-only)  │
+│                                                                    │
+│  GUARDS: one in-flight refresh per client (state.refreshing),      │
+│  5s minimum interval (MIN_REFRESH_INTERVAL_MS)                     │
+│                                                                    │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+Proactive renewal exists because the reactive path alone cannot keep the chain alive: nothing refreshes while the process is idle, so an idle gap longer than the token lifetime lets the refresh chain lapse and forces a new browser login. It is the chain lapsing -- not the access token expiring -- that costs the user a re-login.
+
+`adoptFromStore()` narrows but does not close the multi-process race. There is no cross-process lock, so two clients sharing one store can both attempt a refresh; the loser holds a token the server has already killed and recovers only if the winner has finished persisting. One long-lived process per token store is the intended deployment.
+
+`restoreSession()` backfills `expires_at` for entries persisted before the field existed, and `logout()` clears both `onUnauthorized` and `ensureFreshToken`.
+
+### Session Health
+
+`robinhood_check_session` does not report on stored tokens alone -- loading a token proves nothing about whether it still works. It calls `restoreSession()` and then probes `getAccountProfile()`:
+
+| Status | Meaning |
+|---|---|
+| `logged_in` | Probe succeeded. Returns `account_hint` (last 4 of the account number) |
+| `expired` | Probe raised `AuthenticationError` -- refresh already ran and could not recover. Re-run `robinhood_browser_login` |
+| `unknown` | Probe failed for a non-auth reason (network/transient). The session may well be fine |
+| `not_authenticated` | No tokens in the store |
 
 ## HTTP Layer
 
@@ -288,6 +353,7 @@ session.get(url, params)                <- native fetch
 raiseForStatus(response)
     ├── 404 -> NotFoundError
     ├── 429 -> RateLimitError
+    ├── 401 -> TokenExpiredError  (refresh already ran and failed)
     └── other non-2xx -> APIError(statusCode, responseBody)
     │
     ▼
@@ -313,6 +379,8 @@ RobinhoodError
 ```
 
 Every error carries context. No silent `undefined` returns.
+
+Note the branch: `TokenExpiredError` descends from `AuthenticationError`, **not** `APIError`. A 401 that survives the automatic refresh retry now raises `TokenExpiredError` ("session expired and could not be refreshed. Re-authenticate with browser login.") rather than a bare `APIError: HTTP 401`. Callers that previously matched `APIError` with `statusCode === 401` must catch `AuthenticationError` (or `TokenExpiredError`) instead -- `TokenExpiredError` carries no `statusCode` or `responseBody`.
 
 ## Multi-Account
 
@@ -396,7 +464,8 @@ Stock order payloads include `order_form_version: 7` (required by the Robinhood 
 |---|---|
 | **TokenStore adapters** | Pluggable token storage. KeychainTokenStore for desktop, EncryptedFileTokenStore for Docker/headless. Client never hard-codes a storage strategy. |
 | **Direct Bearer auth** | Session injects `Authorization: Bearer` directly on every request. No proxy, no URL rewriting, no shared secret. Simpler, fewer moving parts. |
-| **401 retry in session** | `onUnauthorized` callback refreshes the token and retries once. Concurrent 401s coalesce into a single refresh. |
+| **Proactive + reactive refresh** | `ensureFreshToken` renews 24h ahead of `expires_at` before each request; `onUnauthorized` refreshes and retries once on a 401 as a fallback. Concurrent 401s coalesce into a single refresh. Proactive is required because refresh tokens are single-use and an idle process would otherwise let the chain lapse. |
+| **`adoptFromStore` over hard failure** | A rejected refresh re-reads the TokenStore before giving up — another process may have already rotated and persisted a working token. Narrows the multi-process race; there is no cross-process lock, so it does not eliminate it. |
 | **Const URL builders** | `API_BASE`, `NUMMUS_BASE`, `BONFIRE_BASE`, and `DORA_BASE` are `const` -- no mutable state, no `configureProxy()`. All URLs point to Robinhood directly. |
 | **Bun + native fetch** | Zero deps for HTTP, native TS execution, fast startup |
 | **Class-based over module globals** | Instance-scoped session prevents shared mutable state. Testable. |

--- a/docs/DOCKER.md
+++ b/docs/DOCKER.md
@@ -1,6 +1,6 @@
 # Docker (OpenClaw, etc.)
 
-**TL;DR** -- Run `onboard` on the host to login and export an encrypted token file. Mount the file into the container and pass the encryption key as an env var.
+**TL;DR** -- Run `onboard` on the host to login and export an encrypted token file. Mount the file into the container **read-write** (the SDK rotates and rewrites tokens) and pass the encryption key as an env var.
 
 ---
 
@@ -60,7 +60,7 @@ services:
       - ./tokens.enc:/secrets/tokens.enc:rw
 ```
 
-> **Note:** The volume must be mounted `:rw` (read-write), not `:ro`. When the access token expires, the SDK refreshes it and writes the updated tokens back to the encrypted file. A read-only mount will cause token refresh to fail silently, and the container will lose API access once the current token expires.
+> **Note:** The volume must be mounted `:rw` (read-write), not `:ro`. The SDK renews the access token ahead of expiry (and again on a 401) and writes the updated tokens back to the encrypted file. Every refresh **rotates** the refresh token — Robinhood invalidates the old one the instant the new one is issued — so this file is not a cache, it is the only durable copy. With a read-only mount the running container keeps working off its in-memory token and then finds nothing valid on restart, requiring a fresh `onboard` on the host. Failed writes are logged as `CRITICAL` on stderr; alert on that line.
 
 #### docker run
 
@@ -84,6 +84,30 @@ $ cat /secrets/tokens.enc
 {"iv":"...","tag":"...","ciphertext":"..."}
 ```
 
+### 4. One writer per token file
+
+Robinhood enforces **single-use refresh-token rotation**: each refresh returns a new refresh token and instantly invalidates the previous one. There is no cross-process lock, so two containers sharing one `tokens.enc` will race — the loser refreshes with a token the winner already spent and gets a 401 `invalid_grant`. The SDK recovers by re-reading the file and adopting whatever the other process persisted, but that is a safety net, not a supported topology.
+
+- Do **not** scale a service that shares one `tokens.enc` to more than one replica
+- Do **not** run the host SDK against the keychain and a container against an export of the same token family at the same time
+- Give each independent deployment its own browser login and its own token file
+
+### Re-authenticating a container
+
+A container can never re-authenticate itself: browser login needs Chrome on the host. Renewal keeps the chain alive only while the SDK is actually making requests, so a container that sits idle longer than the refresh-token lifetime will lapse and need a new token file.
+
+Symptoms: API calls raise `TokenExpiredError` ("session expired and could not be refreshed"), and `robinhood_check_session` reports `expired`. (`unknown` means a transient/network failure — retry before re-onboarding.)
+
+Recovery:
+
+```bash
+# On the host
+npx robinhood-for-agents onboard   # re-login, re-export tokens.enc
+docker compose up -d --force-recreate agent
+```
+
+If you rotated the encryption key during onboard, update `ROBINHOOD_TOKEN_KEY` too.
+
 ---
 
 ## How it works
@@ -98,14 +122,14 @@ $ cat /secrets/tokens.enc
 │                               │    │                                    │
 │                               │    │ SDK loads file → decrypts with key │
 │                               │    │ → injects Bearer header on calls   │
-│                               │    │ → re-encrypts on token refresh     │
+│                               │    │ → renews early, re-encrypts on save│
 └───────────────────────────────┘    └────────────────────────────────────┘
 ```
 
 The `EncryptedFileTokenStore`:
 - Decrypts the token file on `restoreSession()` using `ROBINHOOD_TOKEN_KEY`
 - Injects the Bearer header on every Robinhood API request
-- On 401, refreshes the token and writes re-encrypted tokens back to the file
+- Renews the token 24h before it expires (pre-request hook) and again on a 401, writing re-encrypted tokens back to the file each time — each write carries a newly rotated refresh token
 - Uses AES-256-GCM with a random IV per write (authenticated encryption)
 
 ---
@@ -115,7 +139,7 @@ The `EncryptedFileTokenStore`:
 Kill the container. Once it is gone:
 - No process can read the encryption key from its env vars
 - The encrypted file on the host is useless without the key
-- No further token refreshes will occur, so the current access token expires naturally (~8.5 days after it was issued)
+- No further token refreshes will occur, so the current access token expires naturally — its exact lifetime varies (roughly 6–8.5 days from issue), so do not treat any single figure as a guaranteed revocation window
 
 To revoke immediately, delete the encrypted file on the host:
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -8,15 +8,16 @@ A single JSON blob containing:
 
 | Field | Purpose |
 |-------|---------|
-| `access_token` | Bearer token for API calls (~8.5-day expiry) |
-| `refresh_token` | Used with `device_token` to get a new access token |
+| `access_token` | Bearer token for API calls (variable TTL — observed ~6 to ~8.5 days; the real expiry is read from the token's JWT `exp` claim, never assumed) |
+| `refresh_token` | Used with `device_token` to mint a new access token. **Single-use** — see [Token lifetime and rotation](#token-lifetime-and-rotation) |
 | `device_token` | UUID binding the session to a device |
+| `expires_at` | Unix seconds, derived from the access token's JWT `exp` claim. Optional (absent on entries written before the field existed). Used only to schedule proactive renewal — it is decoded without signature verification and is never an authorization decision |
 
-Anyone who has all three can trade on the user's Robinhood account.
+The `access_token` alone is enough to trade on the user's Robinhood account until it expires. The `refresh_token` + `device_token` pair is enough to keep minting new ones indefinitely.
 
 ## Architecture: TokenStore adapters
 
-The client loads tokens from a `TokenStore` and injects `Authorization: Bearer <token>` directly into every request. There is no intermediary proxy. Token refresh on 401 happens inside the client.
+The client loads tokens from a `TokenStore` and injects `Authorization: Bearer <token>` directly into every request. There is no intermediary proxy. Token refresh happens inside the client — proactively before each request once the token is within 24 hours of expiry, and reactively on a 401 as a fallback.
 
 ```
 ┌─── Client (RobinhoodClient) ─────────────────────────────┐
@@ -24,9 +25,14 @@ The client loads tokens from a `TokenStore` and injects `Authorization: Bearer <
 │  TokenStore.load() ──► access_token ──► fetch() with     │
 │  (keychain or file)    in memory       Authorization hdr  │
 │                                                           │
-│  On 401:                                                  │
+│  Before each request (within 24h of expires_at):          │
 │    refresh_token + device_token ──► /oauth2/token/        │
-│    new tokens ──► TokenStore.save()                       │
+│                                                           │
+│  On 401 (fallback):                                       │
+│    refresh_token + device_token ──► /oauth2/token/        │
+│                                                           │
+│  Either path ──► NEW refresh_token ──► TokenStore.save()  │
+│  (old refresh_token is dead the moment the new one issues)│
 │                                                           │
 └────────────────────────────────── api.robinhood.com ──────┘
 ```
@@ -39,6 +45,22 @@ Two TokenStore adapters are provided:
 | `EncryptedFileTokenStore` | AES-256-GCM encrypted file on disk | Docker, headless servers, CI, cloud |
 
 Auto-detection: if `ROBINHOOD_TOKENS_FILE` is set, the SDK uses `EncryptedFileTokenStore`; otherwise it uses `KeychainTokenStore`.
+
+## Token lifetime and rotation
+
+Refresh tokens are **single-use**. Every successful refresh returns a *new* `refresh_token` and Robinhood invalidates the old one immediately — replaying it returns `HTTP 401 invalid_grant`. Issuing a new token family also revokes the previous **access** token.
+
+Access-token TTL is **not fixed**. The `expires_in` we request (`734000`, ~8.5 days) is only sometimes honored; observed lifetimes run from ~5.9 to ~8.5 days. The client therefore reads the JWT `exp` claim off the access token (`deriveExpiresAt()` in `src/client/token-store.ts`) and persists it as `expires_at` rather than assuming a duration.
+
+**Refresh is proactive, not just reactive.** `RobinhoodSession.ensureFreshToken` runs before every request and renews once the token is within 24 hours of `expires_at` (`REFRESH_SKEW_SEC` in `src/client/auth.ts`); the 401 handler remains as a fallback. Waiting for a 401 alone was not enough — nothing refreshes while the process is idle, so an idle gap longer than the token lifetime let the refresh chain lapse and forced a full browser re-login.
+
+Consequences worth knowing:
+
+- **A stolen refresh token is a race, not a silent clone.** Whoever refreshes first invalidates the other side. If your client suddenly demands a browser re-login for no apparent reason, treat that as a possible signal that someone else used your refresh token — check the Robinhood app for unrecognized sessions.
+- **Re-running browser login revokes the previous family.** That is the cheapest incident response available: a fresh login kills any access or refresh token an attacker copied earlier.
+- **Two processes sharing one store will poison each other.** There is no cross-process lock. If the MCP server and a script refresh concurrently, the loser is left holding a token the server has already killed. `adoptFromStore()` (`src/client/auth.ts`) recovers by re-reading the store and adopting whatever the winner persisted, but it narrows the window rather than closing it. Run one long-lived process per token store.
+- **A failed save is fatal to the chain, not a warning.** Because rotation is server-enforced, the token just spent is already dead; if the replacement cannot be persisted it exists only in memory. The client logs a `CRITICAL` line to stderr in that case. Treat that message as "a browser re-login will be required as soon as this process exits."
+- **`expires_at` comes from an unverified JWT payload.** It is decoded without checking the signature, is used only to schedule renewal, and never gates an authorization decision — but it is not a trusted assertion.
 
 ## KeychainTokenStore — threat model
 
@@ -77,7 +99,7 @@ This is the critical tradeoff. See the attack scenarios below.
 
 **Two implementation details worth knowing:**
 
-- **File mode is set on creation only.** `writeFile(..., { mode: 0o600 })` applies when the file doesn't already exist; it is not re-asserted on every write, and the write itself isn't atomic (no write-to-temp-then-rename). If the file was ever created with looser permissions by another process, or a write is interrupted mid-flight, that isn't self-healing.
+- **File mode is set on creation only.** `writeFile(..., { mode: 0o600 })` applies when the file doesn't already exist; it is not re-asserted on every write, and the write itself isn't atomic (no write-to-temp-then-rename). If the file was ever created with looser permissions by another process, or a write is interrupted mid-flight, that isn't self-healing. Since refresh tokens are single-use, a torn or failed write is not a lost cache entry — it strands the rotated token in memory and costs a browser re-login. The client logs a `CRITICAL` line to stderr when a post-refresh save fails.
 - **A persistent `ROBINHOOD_TOKEN_KEY` (e.g., exported from a shell profile like `.zshrc`) puts the key in plaintext on disk in that dotfile, and hands it to every child process spawned from that shell** — not just this SDK. That's a real, ongoing exposure distinct from the Docker-container scenario below (no container boundary involved at all), and it's easy to set up once for convenience and forget about. Prefer the OS keychain for the key unless you specifically need portability.
 
 ## Attack scenarios
@@ -177,7 +199,7 @@ But a motivated attacker with code execution can trivially decrypt the tokens by
 - **Use read-only filesystem** where possible (`docker run --read-only`) to prevent the agent from writing exfiltration scripts to disk.
 - **Restrict network egress** to `api.robinhood.com` only, preventing token exfiltration to third-party servers.
 - **Set `ROBINHOOD_TOKEN_KEY` via Docker secrets** (not `docker run -e`) to avoid exposure in `docker inspect` output.
-- **Rotate tokens** by re-running browser auth periodically. Access tokens expire in ~8.5 days.
+- **Re-run browser auth periodically** to revoke the current token family. Renewal is automatic while the container is running, so this is a revocation practice, not a keep-alive one — but note that a container idle longer than the access-token lifetime (variable, ~6 to ~8.5 days) will let the refresh chain lapse and require a fresh login.
 - **Monitor API activity** in the Robinhood app for unexpected trades or account actions.
 
 ### Setup
@@ -200,7 +222,7 @@ docker run \
 
 - Use `KeychainTokenStore` (the default) — no tokens on disk, no env vars
 - Agent permission models (e.g., Claude Code approval prompts) provide an additional layer
-- The client handles token refresh automatically on 401
+- The client handles token refresh automatically — proactively 24 hours before expiry, and on a 401 as a fallback
 
 ### Never do this
 
@@ -217,7 +239,8 @@ The previous architecture used a host-side auth proxy (`127.0.0.1:3100`) that in
 |----------|-----------------|--------------------------|
 | Tokens in container | Never | Yes (encrypted) in Docker |
 | Network dependency | Proxy must be running | Direct to `api.robinhood.com` |
-| Token refresh | Proxy handled it | Client handles it on 401 |
+| Token refresh | Proxy handled it | Client handles it — proactive (pre-request, 24h skew) + reactive (401) |
 | Container isolation | Strong — tokens physically absent | Weaker — encrypted tokens present |
 | Operational complexity | Higher — proxy process, proxy token, port forwarding | Lower — single env var + file |
+
 The auth proxy provided stronger isolation for Docker deployments at the cost of operational complexity. The TokenStore approach trades some container isolation for simplicity, with the explicit understanding that **Docker deployments rely on trusting the agent** rather than on cryptographic isolation.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "robinhood-for-agents",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "type": "module",
   "description": "AI-native Robinhood trading interface — MCP server + TypeScript client",
   "license": "MIT",

--- a/skills/robinhood-for-agents/SKILL.md
+++ b/skills/robinhood-for-agents/SKILL.md
@@ -9,7 +9,7 @@ install:
     bins: [robinhood-for-agents]
 requires:
   bins: [bun]
-metadata: {"credentials":"OAuth tokens stored via TokenStore adapters: KeychainTokenStore (OS keychain, default) or EncryptedFileTokenStore (for Docker/headless). restoreSession() loads tokens and injects Bearer auth directly. Access tokens last ~8.5 days and auto-refresh on 401 via the stored refresh token, so the user stays logged in for roughly a week+ before a browser re-login is needed.","chrome":"Google Chrome is required only for initial login (bunx robinhood-for-agents onboard) — playwright-core drives the system Chrome; there is no Brave/Chromium fallback or BROWSER_PATH override. Not needed for subsequent API calls."}
+metadata: {"credentials":"OAuth tokens stored via TokenStore adapters: KeychainTokenStore (OS keychain, default) or EncryptedFileTokenStore (for Docker/headless). restoreSession() loads tokens, injects Bearer auth directly, and registers both proactive renewal (a pre-request hook renews ~24h before expiry) and reactive refresh (on 401). Access-token lifetime varies (~6-8.5 days observed) — never assume a fixed number. Refresh tokens are single-use and rotate on every renewal, so only one client should drive a session at a time. Renewal happens only while the client is in use: a session left idle past the refresh-token lifetime lapses and needs a new browser login.","chrome":"Google Chrome is required only for initial login (bunx robinhood-for-agents onboard) — playwright-core drives the system Chrome; there is no Brave/Chromium fallback or BROWSER_PATH override. Not needed for subsequent API calls."}
 ---
 
 # robinhood-for-agents
@@ -33,7 +33,7 @@ console.log(JSON.stringify(holdings, null, 2));
 
 See [client-api.md](client-api.md) for all available methods and signatures.
 
-> **MCP users:** If you have the `robinhood-for-agents` MCP server configured, you may use MCP tools instead. See [reference.md](reference.md) for tool parameters. MCP is optional — the client API above does everything the MCP tools do.
+> **MCP users:** If you have the `robinhood-for-agents` MCP server configured, you may use MCP tools instead. See [reference.md](reference.md) for tool parameters. MCP is optional — the client API above does everything the MCP tools do. Pick **one** mode per session and stay in it: the MCP server and a `bun -e` script are two separate token-refreshing processes, and refresh tokens are single-use, so interleaving them can poison one of them. In MCP mode, `robinhood_check_session` is the session check — it probes the API rather than just reading the keychain.
 
 ## CRITICAL SAFETY RULES
 1. **Always confirm before placing any order** — show order preview, get explicit "yes"
@@ -64,11 +64,25 @@ See [client-api.md](client-api.md) for all available methods and signatures.
 Read the corresponding domain file for detailed workflow instructions.
 
 ## Authentication Prerequisite
-Before any data-fetching or trading operation, verify the session is active:
+Before any data-fetching or trading operation, verify the session actually works. `restoreSession()` only loads tokens from the store — it does **not** prove they are still valid, so probe with a real call:
 ```bash
-bun -e 'import { getClient } from "robinhood-for-agents"; const rh = getClient(); await rh.restoreSession(); console.log("ok");'
+bun -e '
+import { getClient, AuthenticationError } from "robinhood-for-agents";
+const rh = getClient();
+try {
+  await rh.restoreSession();
+  await rh.getAccountProfile();          // the probe — this is what proves the token works
+  console.log("logged_in");
+} catch (e) {
+  console.log(e instanceof AuthenticationError ? `expired: ${e.name}` : `unknown: ${e}`);
+}
+'
 ```
-If it throws, follow [setup.md](setup.md) to authenticate.
+- `logged_in` → proceed.
+- `expired` (`TokenExpiredError` / `AuthenticationError`) → the tokens are dead and could not be refreshed. Follow [setup.md](setup.md) to re-authenticate.
+- `unknown` → a transient/network failure. The session may well be fine — **do not** send the user through a browser re-login on this; retry once first.
+
+> **MCP mode:** call `robinhood_check_session` instead — it probes the API and returns `logged_in` / `expired` / `unknown` / `not_authenticated`. Only `expired` and `not_authenticated` warrant `robinhood_browser_login`.
 
 ## Client Methods
 
@@ -80,4 +94,6 @@ The client exposes 70+ async methods across auth, portfolio, research, options, 
 ## Important Notes
 - **Do NOT use `phoenix.robinhood.com`** — use `api.robinhood.com` endpoints only
 - Multi-account is first-class: always ask which account when multiple exist
-- Session tokens (access token) last ~8.5 days; the client auto-refreshes on 401 via the stored refresh token, so re-auth is only needed roughly once a week+
+- Session tokens renew themselves: the client refreshes proactively (~24h before expiry) and again on a 401, so a session in regular use stays alive without a re-login. Access-token TTL varies (~6-8.5 days observed) — never quote a fixed number
+- Refresh tokens are **single-use**: every renewal issues a new one and instantly kills the old (and revokes the previous access token). Run one client at a time — MCP server *or* a `bun -e` script, not both; a second process gets poisoned. It self-heals by re-reading the token store, but there is no cross-process lock
+- Renewal only happens while the client is being used. A session left idle past the refresh-token lifetime lapses and needs a **new browser login** — see [setup.md](setup.md)

--- a/skills/robinhood-for-agents/client-api.md
+++ b/skills/robinhood-for-agents/client-api.md
@@ -5,19 +5,67 @@ Methods from `robinhood-for-agents` for programmatic access without MCP.
 ## Quick Start
 
 ```typescript
-import { RobinhoodClient, getClient } from "robinhood-for-agents";
+import { RobinhoodClient, getClient, TokenExpiredError } from "robinhood-for-agents";
 
 const rh = getClient(); // singleton
+await rh.restoreSession();  // loads tokens + wires refresh — does NOT validate them
+```
+
+`restoreSession()` reads the token store and registers both refresh paths (a pre-request hook that renews ~24h before expiry, plus a 401 handler). It proves nothing about whether the tokens still work — the first real call is where a dead session surfaces, as a `TokenExpiredError`. To verify up front, probe:
+
+```typescript
 await rh.restoreSession();
+await rh.getAccountProfile();  // throws TokenExpiredError if the session is dead
 ```
 
 All methods are `async`. Multi-account is first-class: account-scoped methods accept `accountNumber`.
+
+## Errors & Session Expiry
+
+```
+RobinhoodError
+├── AuthenticationError
+│   └── TokenExpiredError     // 401 that survived automatic refresh
+├── NotLoggedInError
+└── APIError                  // every other non-2xx
+    ├── RateLimitError        // 429
+    └── NotFoundError         // 404
+```
+
+Catch `AuthenticationError` (or `TokenExpiredError` specifically) for auth failures — **not** `APIError`. A 401 is no longer surfaced as a bare `APIError: HTTP 401`: `TokenExpiredError` is thrown only after automatic refresh has already run and failed, so it means "re-authenticate", never "retry".
+
+```typescript
+import { getClient, AuthenticationError, TokenExpiredError, APIError } from "robinhood-for-agents";
+
+try {
+  await rh.getAccountProfile();
+} catch (e) {
+  if (e instanceof TokenExpiredError) {
+    // refresh already tried and failed — only a browser login fixes this
+    // (`bunx robinhood-for-agents onboard`, or the robinhood_browser_login MCP tool)
+  } else if (e instanceof AuthenticationError) {
+    // no tokens in the store at all — same remedy
+  } else if (e instanceof APIError) {
+    // a real API error (404/429/5xx) — the session is fine
+  } else {
+    // network/transient — the session may well be fine; retry before re-authenticating
+  }
+}
+```
+
+**How refresh works.** `restoreSession()` registers two paths: a pre-request hook that renews ~24h before the access token expires (using `TokenData.expires_at`, derived from the JWT `exp` claim), and an `onUnauthorized` handler that renews on a 401. Concurrent 401s share a single refresh attempt, and attempts are rate-limited to one per 5s.
+
+**Single-use rotation — the concurrency rule.** Robinhood rotates refresh tokens: each renewal returns a new refresh token, instantly kills the old one, and revokes the previous access token. Two clients on one session (an MCP server plus a `bun -e` script, or two Claude Code sessions) will poison each other. When a refresh is rejected the client re-reads the token store and adopts a token another process may have persisted, so it usually self-heals — but there is **no cross-process lock**. Drive a session from one process at a time.
+
+**Idle sessions still lapse.** Proactive renewal only runs while the client is making requests. Leave a session idle longer than the refresh-token lifetime and the chain lapses — a new browser login is required. Access-token TTL varies (~6-8.5 days observed); never hard-code a number.
+
+**No-refresh mode.** A client constructed with a direct `accessToken` registers neither refresh path — the first 401 raises `TokenExpiredError` immediately.
 
 ## MCP Tool → Client Method Mapping
 
 | MCP Tool | Client Method |
 |----------|--------------|
-| `robinhood_check_session` | `restoreSession()` |
+| `robinhood_check_session` | `restoreSession()` + a probe call (`getAccountProfile()`) — `restoreSession()` alone does not validate the tokens |
 | `robinhood_get_account` | `getAccountProfile(accountNumber?)` |
 | `robinhood_get_accounts` | `getAccounts(opts?)` |
 | `robinhood_get_portfolio` | `buildHoldings(opts?)` |

--- a/skills/robinhood-for-agents/options.md
+++ b/skills/robinhood-for-agents/options.md
@@ -1,5 +1,7 @@
 # Options — Chain Analysis & Index Options
 
+`restoreSession()` loads tokens but does not validate them — a `TokenExpiredError` from any call below means the session is dead and automatic refresh could not recover it; re-authenticate via [setup.md](setup.md) rather than retrying.
+
 ## Fetching Options Data
 
 ```bash

--- a/skills/robinhood-for-agents/portfolio.md
+++ b/skills/robinhood-for-agents/portfolio.md
@@ -1,5 +1,7 @@
 # Portfolio — Holdings, P&L, Account Summary
 
+`restoreSession()` loads tokens but does not validate them — a `TokenExpiredError` from any call below means the session is dead and automatic refresh could not recover it; re-authenticate via [setup.md](setup.md) rather than retrying.
+
 ### Fetch Portfolio Data
 
 ```bash

--- a/skills/robinhood-for-agents/reference.md
+++ b/skills/robinhood-for-agents/reference.md
@@ -3,16 +3,27 @@
 ## Auth
 
 ### robinhood_check_session
-Check if a Robinhood session is active.
+Check whether there is a *working* Robinhood session. Loads the cached tokens **and probes the API** with them — it does not report healthy merely because tokens exist in the keychain.
 
 **Parameters:** none
 
-**Response:** `{ "status": "logged_in" | "not_authenticated" }`
+**Response:** `{ "status": "logged_in" | "expired" | "unknown" | "not_authenticated", "method": "keychain" | "encrypted_file" | "token", "account_hint": "...1234", "message": "..." }`
+
+| `status` | Meaning | What to do |
+|---|---|---|
+| `logged_in` | verified working; `account_hint` is the masked account number | proceed |
+| `expired` | tokens exist but are dead and automatic refresh could not recover them | run `robinhood_browser_login` |
+| `unknown` | the probe failed for a transient/network reason — the session may well be fine | retry; **do not** assume expired, do not re-login |
+| `not_authenticated` | no tokens in the store at all | run `robinhood_browser_login` |
+
+`account_hint` is present only on `logged_in`; `message` carries the reason on `expired` / `unknown` / `not_authenticated`. This tool makes a live API call, so it is not free — check once at the start of a session, not before every tool call.
 
 ### robinhood_browser_login
-Open Chrome for browser-based Robinhood login. Captures OAuth tokens automatically.
+Open Chrome for browser-based Robinhood login. Captures OAuth tokens automatically. This is the remedy for `robinhood_check_session` returning `expired` or `not_authenticated` — and the *only* remedy; there is no programmatic re-auth.
 
 **Parameters:** none
+
+**Response:** `{ "status": "logged_in", "account_hint": "...1234" }`
 
 **Timeout note for MCP client authors:** this call waits up to 5 minutes server-side for the user to complete login (including MFA) before the OAuth token exchange resolves. Most MCP SDKs default `callTool`'s request timeout to 60 seconds, which is shorter than that — if you're driving this tool programmatically (not through Claude Code, which already handles this), pass a longer per-call timeout (e.g. the TypeScript SDK's `client.callTool(params, resultSchema, { timeout: 330_000 })`) or the call will abort client-side while the user is still mid-login.
 
@@ -30,6 +41,9 @@ Get account details, profile, and investment preferences.
   "investment": { "risk_tolerance": "moderate" }
 }
 ```
+
+### Session errors on any tool
+Tokens renew automatically — proactively ~24h before expiry, and again on a 401. When a tool still returns an error containing `session expired and could not be refreshed`, refresh has already been tried and failed: run `robinhood_browser_login`, don't retry the tool. Refresh tokens are single-use and rotate on every renewal, so avoid driving the same session from a second process (a `bun -e` script alongside this server) — one of them will be poisoned.
 
 ## Account & Portfolio
 

--- a/skills/robinhood-for-agents/research.md
+++ b/skills/robinhood-for-agents/research.md
@@ -1,5 +1,7 @@
 # Research — Stock Analysis
 
+`restoreSession()` loads tokens but does not validate them — a `TokenExpiredError` from any call below means the session is dead and automatic refresh could not recover it; re-authenticate via [setup.md](setup.md) rather than retrying. (In a parallel `Promise.all`, one expired session fails every branch at once — that is one auth failure, not seven.)
+
 ### Fetch Data (parallel)
 
 ```bash

--- a/skills/robinhood-for-agents/setup.md
+++ b/skills/robinhood-for-agents/setup.md
@@ -1,17 +1,31 @@
 # Setup — Authentication Workflow
 
 ### Step 1: Check Session
+`restoreSession()` only loads tokens from the store — it succeeds even for tokens the server has already killed. Probe the API to know the truth:
 ```bash
 bun -e '
-import { getClient } from "robinhood-for-agents";
+import { getClient, AuthenticationError } from "robinhood-for-agents";
 const rh = getClient();
-try { await rh.restoreSession(); console.log("logged_in"); }
-catch { console.log("not_authenticated"); }
+try {
+  await rh.restoreSession();
+  const acct = await rh.getAccountProfile();       // the probe
+  console.log("logged_in", `...${String(acct.account_number).slice(-4)}`);
+} catch (e) {
+  if (e instanceof AuthenticationError) console.log(e.name === "TokenExpiredError" ? "expired" : "not_authenticated");
+  else console.log("unknown:", String(e));
+}
 '
 ```
-If `logged_in` — already authenticated, stop. Otherwise continue.
+| Result | Meaning | Do |
+|---|---|---|
+| `logged_in` | verified working (account hint shown) | stop — already authenticated |
+| `expired` | tokens exist but are dead and could not be refreshed | Step 2 |
+| `not_authenticated` | no tokens in the store at all | Step 2 |
+| `unknown` | transient/network failure — the session may well be fine | retry once; **do not** re-login on this alone |
 
-`restoreSession()` loads tokens from the configured TokenStore (OS keychain by default) and injects Bearer auth directly into API requests.
+`restoreSession()` loads tokens from the configured TokenStore (OS keychain by default), injects Bearer auth directly into API requests, and registers both refresh paths: a pre-request hook that renews ~24h before expiry, and a 401 handler that renews reactively.
+
+> **MCP mode:** call `robinhood_check_session` — it performs this probe server-side and returns the same four statuses (`logged_in` / `expired` / `unknown` / `not_authenticated`) plus a masked `account_hint`. Remedy for `expired` / `not_authenticated` is `robinhood_browser_login`.
 
 ### Step 2: Browser Login
 ```bash
@@ -34,6 +48,8 @@ const acct = await rh.getAccountProfile();
 console.log(JSON.stringify(acct, null, 2));
 '
 ```
+This call is the actual verification — reaching the account profile is what proves the token works. If it throws `TokenExpiredError` immediately after a successful browser login, suspect a second client (an MCP server, another Claude Code session) that rotated the refresh token out from under this one; close the other process and re-run Step 2.
+
 Confirm to the user that authentication is complete.
 
 ## Token Stores
@@ -42,15 +58,20 @@ Confirm to the user that authentication is complete.
 |---|---|---|
 | `KeychainTokenStore` (default) | Local dev, macOS/Linux with desktop | Nothing — works out of the box |
 | `EncryptedFileTokenStore` | Docker, headless servers, CI, cloud | Set `ROBINHOOD_TOKENS_FILE` + `ROBINHOOD_TOKEN_KEY` env vars |
-| Direct `accessToken` | Serverless, testing, short-lived scripts | Pass `accessToken` to constructor |
+| Direct `accessToken` | Serverless, testing, short-lived scripts | Pass `accessToken` to constructor — **no refresh at all** (neither proactive nor on 401); the first 401 raises `TokenExpiredError` |
 
 ## Troubleshooting
-- **`not_authenticated` after login**: Try `bunx robinhood-for-agents onboard` to re-login
-- **Token expired**: Tokens auto-refresh on 401. If refresh fails, re-run `onboard`
+- **`not_authenticated`**: no tokens in the store — run `bunx robinhood-for-agents onboard`
+- **`expired` / `TokenExpiredError`**: tokens exist but are dead and automatic refresh could not recover them. Re-run `onboard` (MCP: `robinhood_browser_login`) — there is no other remedy
+- **`unknown`**: the probe failed for a transient/network reason. The session is probably fine — retry before re-authenticating; never re-login on `unknown` alone
+- **Worked a minute ago, now 401s**: refresh tokens are **single-use** — each renewal issues a new one and instantly kills the old (and revokes the previous access token). Two clients sharing one session (MCP server + a CLI script, or two Claude Code sessions) will poison each other. The client self-heals by re-reading the token store and adopting whatever the other process persisted, but there is no cross-process lock — close the second process, then re-run `onboard` if it stays broken
+- **Back after days away**: renewal only runs while the client is in use. Idle longer than the refresh-token lifetime and the chain lapses — a **new browser login** is required
+- **`CRITICAL: refreshed tokens could not be persisted`** in stderr: the rotated refresh token exists only in memory and dies with the process. Fix keychain/`ROBINHOOD_TOKENS_FILE` access, then re-run `onboard`
 - **Docker/headless**: Set `ROBINHOOD_TOKENS_FILE` and `ROBINHOOD_TOKEN_KEY` env vars
 
 ## Notes
 - No credentials (username/password) pass through the tool layer — login happens on the real Robinhood website
 - Tokens are stored in the OS keychain via `Bun.secrets` (default) — never on disk in plaintext
-- Access tokens last ~8.5 days; the client auto-refreshes on 401 via the stored refresh token, so re-auth is only needed roughly once a week+
+- Access-token TTL varies (~6-8.5 days observed) — never assume a fixed number. The client renews twice over: proactively via a pre-request hook ~24h before expiry, and reactively on a 401
+- Each renewal rotates the refresh token (single-use) and revokes the previous access token, so a session in regular use keeps rolling forward — but only one client may drive it, and only while it is being used
 - The client injects `Authorization: Bearer` headers directly into API requests

--- a/skills/robinhood-for-agents/trade.md
+++ b/skills/robinhood-for-agents/trade.md
@@ -2,6 +2,8 @@
 
 **CRITICAL: Safety rules in SKILL.md apply to ALL operations below. Always confirm with the user before placing any order.**
 
+**Session first.** Verify the session per [SKILL.md](SKILL.md#authentication-prerequisite) *before* Step 1 — `restoreSession()` succeeds on dead tokens, so an unverified session fails partway through the flow instead of up front. If any step throws `TokenExpiredError`, **stop**: re-authenticate via [setup.md](setup.md), then restart from Step 3 (re-review) — never place an order against a review taken before a re-login. Run one client at a time during an order flow; refresh tokens are single-use and a competing process can invalidate the session mid-order.
+
 ## Order Flow
 
 ### Step 1: Resolve Account
@@ -54,6 +56,8 @@ Proceed? (yes/no)
 Wait for the user to explicitly confirm. If the quote in the review has since gone stale, re-run the review before placing.
 
 ### Step 5: Place Order (after user confirms)
+
+If the place call fails with `TokenExpiredError`, the order was **not** placed — the request never reached Robinhood. Re-authenticate ([setup.md](setup.md)), then re-run Step 3 and re-confirm with the user before trying again; do not blind-retry the place call.
 
 ## Stock Orders
 

--- a/skills/robinhood-for-agents/watchlists.md
+++ b/skills/robinhood-for-agents/watchlists.md
@@ -4,6 +4,8 @@
 
 Watchlists are identified by **list_id (UUID)** — there is no "default list" shortcut, by design (so a write can never hit the wrong list).
 
+`restoreSession()` loads tokens but does not validate them. A `TokenExpiredError` on a write means the write did **not** land — re-authenticate via [setup.md](setup.md), re-read the list to confirm its actual state, then redo only the missing operation. This matters most for the two-call move (remove then add): if the second call dies on auth, the symbol is off the source list and not yet on the target.
+
 ## Step 1: Look Up the List
 
 ```bash

--- a/src/client/auth.ts
+++ b/src/client/auth.ts
@@ -8,10 +8,20 @@
 
 import { AuthenticationError } from "./errors.js";
 import type { RobinhoodSession } from "./session.js";
-import type { TokenData, TokenStore } from "./token-store.js";
+import { deriveExpiresAt, type TokenData, type TokenStore } from "./token-store.js";
 
 const CLIENT_ID = "c82SH0WZOsabOXGP2sxqcj34FxkvfnWRZBKlBjFS";
 const EXPIRATION_TIME = 734000;
+
+/**
+ * Renew this far ahead of expiry rather than waiting for a 401.
+ *
+ * Robinhood grants roughly 8.5 days on a refresh, so a day of slack leaves
+ * plenty of room while keeping the refresh chain alive: every renewal issues a
+ * fresh refresh token, and it is the chain lapsing — not the access token
+ * expiring — that forces a new browser login.
+ */
+const REFRESH_SKEW_SEC = 24 * 60 * 60;
 
 export interface LoginResult {
   status: "logged_in";
@@ -29,6 +39,30 @@ export interface AuthState {
 }
 
 /**
+ * A refresh attempt failed. Another process may have already rotated the token
+ * and persisted a working one, so reload the store before giving up rather than
+ * failing while a valid credential sits on disk.
+ *
+ * Refresh tokens are single-use: once any process refreshes, every other
+ * process is holding a token the server has already invalidated, and its
+ * in-memory copy can never recover on its own.
+ */
+async function adoptFromStore(state: AuthState, attempted: string): Promise<string | null> {
+  let stored: TokenData | null;
+  try {
+    stored = await state.store.load();
+  } catch {
+    return null;
+  }
+
+  // Same token we just tried means nobody else refreshed — nothing to adopt.
+  if (!stored || stored.refresh_token === attempted) return null;
+
+  state.tokens = stored;
+  return stored.access_token;
+}
+
+/**
  * Refresh the access token using the refresh_token + device_token.
  * Returns the new access token on success, null on failure.
  */
@@ -36,26 +70,33 @@ async function refreshTokens(state: AuthState): Promise<string | null> {
   const { tokens, store } = state;
   if (!tokens.refresh_token || !tokens.device_token) return null;
 
+  const attempted = tokens.refresh_token;
+
   const body = new URLSearchParams({
     grant_type: "refresh_token",
-    refresh_token: tokens.refresh_token,
+    refresh_token: attempted,
     scope: "internal",
     client_id: CLIENT_ID,
     expires_in: String(EXPIRATION_TIME),
     device_token: tokens.device_token,
   });
 
-  const resp = await fetch("https://api.robinhood.com/oauth2/token/", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
-      "X-Robinhood-API-Version": "1.431.4",
-    },
-    body: body.toString(),
-    signal: AbortSignal.timeout(10_000),
-  });
+  let resp: Response;
+  try {
+    resp = await fetch("https://api.robinhood.com/oauth2/token/", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+        "X-Robinhood-API-Version": "1.431.4",
+      },
+      body: body.toString(),
+      signal: AbortSignal.timeout(10_000),
+    });
+  } catch {
+    return adoptFromStore(state, attempted);
+  }
 
-  if (!resp.ok) return null;
+  if (!resp.ok) return adoptFromStore(state, attempted);
 
   let data: Record<string, unknown>;
   try {
@@ -66,22 +107,36 @@ async function refreshTokens(state: AuthState): Promise<string | null> {
 
   if (!("access_token" in data)) return null;
 
+  const accessToken = data.access_token as string;
+  const savedAt = Date.now() / 1000;
   const newTokens: TokenData = {
-    access_token: data.access_token as string,
-    refresh_token: (data.refresh_token as string) ?? tokens.refresh_token,
+    access_token: accessToken,
+    refresh_token: (data.refresh_token as string) ?? attempted,
     token_type: (data.token_type as string) ?? "Bearer",
     device_token: tokens.device_token,
-    saved_at: Date.now() / 1000,
+    account_hint: tokens.account_hint,
+    saved_at: savedAt,
+    expires_at: deriveExpiresAt(accessToken, {
+      expiresIn: typeof data.expires_in === "number" ? data.expires_in : undefined,
+      issuedAt: savedAt,
+    }),
   };
 
   // Update in-memory state
   state.tokens = newTokens;
 
-  // Persist to store (best-effort)
+  // Persist before the caller uses the new access token. Rotation is enforced
+  // server-side: `attempted` is already dead, so a lost save leaves the only
+  // copy of the new refresh token in memory and strands the next process start.
+  // That is not a benign degradation, so it must not be swallowed silently.
   try {
     await store.save(newTokens);
-  } catch {
-    // Store unavailable — tokens live in memory only
+  } catch (e) {
+    console.error(
+      "[robinhood-for-agents] CRITICAL: refreshed tokens could not be persisted " +
+        `(${e instanceof Error ? e.message : String(e)}). The rotated refresh token now ` +
+        "exists only in memory — once this process exits a new browser login will be required.",
+    );
   }
 
   return newTokens.access_token;
@@ -109,6 +164,31 @@ function createRefreshCallback(state: AuthState): () => Promise<string | null> {
 }
 
 /**
+ * Create the pre-request hook that renews the token before it expires.
+ *
+ * Waiting for a 401 is not enough on its own: nothing refreshes while the
+ * process is idle, so a gap longer than the refresh-token lifetime lets the
+ * chain lapse and forces a new browser login. Renewing ahead of expiry keeps
+ * the chain alive for as long as the client is actually being used.
+ */
+function createEnsureFreshCallback(
+  state: AuthState,
+  session: RobinhoodSession,
+  refresh: () => Promise<string | null>,
+): () => Promise<void> {
+  return async () => {
+    const expiresAt = state.tokens.expires_at;
+    // Unknown expiry (non-JWT token, or a store entry predating the field):
+    // leave it to the reactive 401 path rather than refreshing on every call.
+    if (expiresAt === undefined) return;
+    if (Date.now() / 1000 < expiresAt - REFRESH_SKEW_SEC) return;
+
+    const token = await refresh();
+    if (token) session.setAccessToken(token);
+  };
+}
+
+/**
  * Restore a session by loading tokens from the store and configuring
  * the session for direct API access with automatic token refresh.
  */
@@ -123,6 +203,12 @@ export async function restoreSession(
     );
   }
 
+  // Backfill expiry for entries persisted before `expires_at` existed, so
+  // proactive renewal works without waiting for a re-login.
+  if (tokens.expires_at === undefined) {
+    tokens.expires_at = deriveExpiresAt(tokens.access_token, { issuedAt: tokens.saved_at });
+  }
+
   // Set access token on the session for Bearer injection
   session.setAccessToken(tokens.access_token);
 
@@ -134,8 +220,11 @@ export async function restoreSession(
     lastRefreshAt: 0,
   };
 
-  // Register 401 callback for automatic token refresh
-  session.onUnauthorized = createRefreshCallback(state);
+  // Register 401 callback for automatic token refresh, plus the pre-request
+  // hook that renews ahead of expiry so the refresh chain does not lapse.
+  const refresh = createRefreshCallback(state);
+  session.onUnauthorized = refresh;
+  session.ensureFreshToken = createEnsureFreshCallback(state, session, refresh);
 
   const method = store.constructor.name.includes("Encrypted") ? "encrypted_file" : "keychain";
 
@@ -189,4 +278,5 @@ export async function logout(session: RobinhoodSession, state: AuthState | null)
 
   session.clearAccessToken();
   session.onUnauthorized = null;
+  session.ensureFreshToken = null;
 }

--- a/src/client/http.ts
+++ b/src/client/http.ts
@@ -2,7 +2,7 @@
 
 import { z } from "zod";
 import { redactTokens, scrubSensitiveKeys } from "../redact.js";
-import { APIError, NotFoundError, RateLimitError } from "./errors.js";
+import { APIError, NotFoundError, RateLimitError, TokenExpiredError } from "./errors.js";
 import type { RobinhoodSession } from "./session.js";
 import { trustedOrigins } from "./urls.js";
 
@@ -142,6 +142,14 @@ async function raiseForStatus(response: Response): Promise<void> {
   }
   if (status === 429) {
     throw new RateLimitError(msg, { statusCode: status, responseBody: safeBody });
+  }
+  // A 401 here means automatic refresh already ran and could not recover, so
+  // the session is genuinely unusable. Say that, instead of a bare HTTP 401
+  // that gives the caller no idea a re-login is what's needed.
+  if (status === 401) {
+    throw new TokenExpiredError(
+      `${msg} — session expired and could not be refreshed. Re-authenticate with browser login.`,
+    );
   }
   throw new APIError(msg, { statusCode: status, responseBody: safeBody });
 }

--- a/src/client/session.ts
+++ b/src/client/session.ts
@@ -56,6 +56,14 @@ export class RobinhoodSession {
    */
   onUnauthorized: (() => Promise<string | null>) | null = null;
 
+  /**
+   * Called before each request. Should renew the access token if it is close
+   * to expiring and update it via `setAccessToken`. Failures are swallowed —
+   * a proactive refresh that does not work simply falls through to the
+   * reactive `onUnauthorized` path.
+   */
+  ensureFreshToken: (() => Promise<void>) | null = null;
+
   constructor(opts?: { timeoutMs?: number }) {
     this.headers = { ...DEFAULT_HEADERS };
     this.timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -145,27 +153,51 @@ export class RobinhoodSession {
     });
   }
 
+  /** Return a copy of `init` with the Authorization header re-stamped. */
+  private withAuthHeader(
+    init: RequestInit & { signal: AbortSignal },
+    token: string,
+  ): RequestInit & { signal: AbortSignal } {
+    const headers =
+      init.headers instanceof Headers
+        ? Object.fromEntries(init.headers)
+        : { ...(init.headers as Record<string, string>) };
+    headers.Authorization = `Bearer ${token}`;
+    return { ...init, headers };
+  }
+
   /**
-   * Fetch with single-retry on 401. If onUnauthorized is set and the first
-   * request returns 401, refresh the token and retry once.
+   * Fetch with proactive renewal plus single-retry on 401.
+   *
+   * Callers bake the Authorization header before calling this, so a proactive
+   * refresh that swaps the token must re-stamp the header or the request would
+   * still go out with the stale one.
    */
   private async fetchWithRetry(
     url: string,
     init: RequestInit & { signal: AbortSignal },
   ): Promise<Response> {
-    const resp = await safeFetch(url, init);
+    let req = init;
+
+    if (this.ensureFreshToken) {
+      const before = this.accessToken;
+      try {
+        await this.ensureFreshToken();
+      } catch {
+        // Proactive renewal is best-effort; fall through to the 401 path.
+      }
+      if (this.accessToken && this.accessToken !== before) {
+        req = this.withAuthHeader(req, this.accessToken);
+      }
+    }
+
+    const resp = await safeFetch(url, req);
 
     if (resp.status === 401 && this.onUnauthorized) {
       const newToken = await this.onUnauthorized();
       if (newToken) {
         this.accessToken = newToken;
-        // Rebuild headers with new token
-        const headers =
-          init.headers instanceof Headers
-            ? Object.fromEntries(init.headers)
-            : { ...(init.headers as Record<string, string>) };
-        headers.Authorization = `Bearer ${newToken}`;
-        return safeFetch(url, { ...init, headers });
+        return safeFetch(url, this.withAuthHeader(req, newToken));
       }
     }
 

--- a/src/client/token-store.ts
+++ b/src/client/token-store.ts
@@ -29,6 +29,14 @@ export interface TokenData {
   device_token: string;
   account_hint?: string;
   saved_at: number;
+  /**
+   * Unix seconds at which `access_token` expires.
+   *
+   * Optional so that tokens persisted before this field existed still load and
+   * validate — they simply fall back to reactive (401-triggered) refresh until
+   * the next successful refresh backfills it.
+   */
+  expires_at?: number;
 }
 
 export function isTokenData(data: unknown): data is TokenData {
@@ -43,9 +51,47 @@ export function isTokenData(data: unknown): data is TokenData {
   );
 }
 
-/** Add `saved_at` timestamp if missing. */
+/** Read the `exp` claim from a JWT access token without verifying its signature. */
+function jwtExp(accessToken: string): number | undefined {
+  const [, encodedPayload, signature] = accessToken.split(".");
+  if (!encodedPayload || !signature) return undefined;
+  try {
+    const payload: unknown = JSON.parse(Buffer.from(encodedPayload, "base64url").toString("utf8"));
+    if (typeof payload !== "object" || payload === null) return undefined;
+    const exp = (payload as Record<string, unknown>).exp;
+    return typeof exp === "number" && Number.isFinite(exp) ? exp : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolve when an access token expires, in unix seconds.
+ *
+ * Prefers the JWT `exp` claim — it is authoritative and present on tokens from
+ * both the browser-login capture and the refresh grant. Falls back to
+ * `issuedAt + expiresIn` when the token is not a decodable JWT.
+ */
+export function deriveExpiresAt(
+  accessToken: string,
+  opts?: { expiresIn?: number; issuedAt?: number },
+): number | undefined {
+  const claim = jwtExp(accessToken);
+  if (claim !== undefined) return claim;
+  if (opts?.expiresIn !== undefined && Number.isFinite(opts.expiresIn)) {
+    return (opts.issuedAt ?? Date.now() / 1000) + opts.expiresIn;
+  }
+  return undefined;
+}
+
+/** Add `saved_at` timestamp if missing, deriving `expires_at` when not supplied. */
 export function withTimestamp(tokens: Omit<TokenData, "saved_at">): TokenData {
-  return { ...tokens, saved_at: Date.now() / 1000 };
+  const saved_at = Date.now() / 1000;
+  return {
+    ...tokens,
+    saved_at,
+    expires_at: tokens.expires_at ?? deriveExpiresAt(tokens.access_token, { issuedAt: saved_at }),
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/tools/auth.ts
+++ b/src/server/tools/auth.ts
@@ -52,14 +52,35 @@ export function registerAuthTools(server: McpServer): void {
         const rh = getRh();
         try {
           const result = await rh.restoreSession();
+
+          // restoreSession only loads tokens from the store — it proves nothing
+          // about whether they still work. Probe the API before reporting
+          // "logged_in", otherwise an expired session reports healthy while
+          // every subsequent call fails.
           let accountHint = "";
           try {
             const profile = await rh.getAccountProfile();
             const acct = profile.account_number ?? "";
             accountHint = acct.length >= 4 ? `...${acct.slice(-4)}` : acct;
-          } catch {
-            // Skip
+          } catch (probeError) {
+            if (probeError instanceof AuthenticationError) {
+              return structured({
+                status: "expired",
+                method: result.method,
+                message:
+                  "Cached tokens are no longer valid and could not be refreshed. " +
+                  "Run robinhood_browser_login to re-authenticate.",
+              });
+            }
+            // Transient/network failure — the session may well be fine, so do
+            // not claim it is expired either.
+            return structured({
+              status: "unknown",
+              method: result.method,
+              message: `Could not verify session: ${probeError}`,
+            });
           }
+
           return structured({
             status: "logged_in",
             method: result.method,

--- a/src/version.ts
+++ b/src/version.ts
@@ -6,4 +6,4 @@
  * `__tests__/version.test.ts` fails the build if these ever diverge, so the
  * stale-version drift that accumulated across earlier releases can't recur.
  */
-export const VERSION = "1.0.1";
+export const VERSION = "1.1.0";


### PR DESCRIPTION
Refresh was reactive-only: nothing renewed the token while the process was idle, so an idle gap longer than the refresh-token lifetime let the chain lapse and forced a browser re-login. Robinhood enforces single-use refresh token rotation, which made two further failure modes possible.

Client:
- TokenData gains optional `expires_at`, derived by `deriveExpiresAt()` from the JWT `exp` claim (falling back to issuedAt + expires_in). Optional so already-stored entries still load; `restoreSession()` backfills them, so existing logins get proactive renewal without re-authenticating.
- New `RobinhoodSession.ensureFreshToken` pre-request hook renews 24h ahead of expiry. Callers bake the Authorization header before `fetchWithRetry` runs, so the header is re-stamped when the token changes — the extracted `withAuthHeader()` is now shared with the 401 retry path.
- New `adoptFromStore()`: a rejected refresh re-reads the TokenStore and adopts a token another process may have persisted, instead of failing while a valid credential sits in the store.
- A failed post-refresh save is no longer swallowed. Under enforced rotation the spent token is already dead, so a lost save leaves the only copy of the new refresh token in memory; it now logs CRITICAL to stderr.
- A 401 surviving the refresh retry raises TokenExpiredError instead of a bare APIError, which is what auth.ts already documented but did not do.

Server:
- `robinhood_check_session` probes the API instead of reporting logged_in whenever tokens merely exist. Returns logged_in / expired / unknown / not_authenticated — `unknown` keeps a network blip from being reported as an expired session.

Note `refreshTokens()`'s request logic is unchanged; it was verified working against the live API. Every change here is in the surrounding policy.

Docs corrected throughout: access-token lifetime is variable (~6-8.5 days observed), not a fixed ~8.5 days, and refresh is no longer described as 401-only. Adds a single-writer warning and a container re-auth runbook.